### PR TITLE
Tarzan supervisor

### DIFF
--- a/roles/func_accounts/templates/crontab_upps.j2
+++ b/roles/func_accounts/templates/crontab_upps.j2
@@ -1,7 +1,6 @@
 SHELL=/bin/bash
 @reboot source $HOME/.bash_profile && supervisord -c {{ ngi_pipeline_conf }}/supervisord_upps.conf
 
-# TODO: Shall this still be here?? 
 0 * * * * source $HOME/.bashrc &> /dev/null && update_charon_with_local_jobs_status.py -e piper &> /dev/null
 
 # (SNP&SEQ) dump the size of project directories

--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -51,6 +51,7 @@ tarzan_env_path: "{{ luajit_dest }}/{{ luajit_version }}/bin:{{ luarocks_dest }}
 
 tarzan_log_dest: "{{ ngi_pipeline_upps_path }}/log/tarzan/"
 tarzan_db_dest: "{{ ngi_pipeline_upps_path }}/db/tarzan/"
+cassandra_log_dest: "{{ tarzan_log_dest }}/cassandra"
 cassandra_db_dest: "{{ tarzan_db_dest }}/cassandra" 
 
 # To get Tarzan to work lua_path and lua_cpath were generated from a working luarocks 

--- a/roles/tarzan/tasks/dependencies.yml
+++ b/roles/tarzan/tasks/dependencies.yml
@@ -9,7 +9,7 @@
 # use a loop a la http://stackoverflow.com/questions/30785281/one-loop-over-multiple-ansible-tasks ? 
 
 - name: create luajit destination directory 
-  file: path={{ luajit_dest }} state=directory mode=g+s
+  file: path={{ luajit_dest }} state=directory mode=g+rwXs
   tags: tarzan 
 
 - name: download luajit archive
@@ -19,7 +19,12 @@
   tags: tarzan
 
 - name: unpack luajit to destination
-  unarchive: src="{{ luajit_dest }}/{{ luajit_file }}" dest={{ luajit_dest }}/ copy=no creates={{ luajit_dest }}/{{ luajit_version }}/bin/luajit-{{ luajit_version }}
+  unarchive: 
+    src: "{{ luajit_dest }}/{{ luajit_file }}" 
+    dest: "{{ luajit_dest }}"
+    copy: no 
+    creates: "{{ luajit_dest }}/{{ luajit_version }}/bin/luajit-{{ luajit_version }}"
+    mode: g+rwX,o+rX
   tags: tarzan
 
 - name: set luajits install path
@@ -45,7 +50,7 @@
   tags: tarzan
 
 - name: create luarocks destination directory
-  file: path={{ luarocks_dest }} state=directory mode=g+s
+  file: path={{ luarocks_dest }} state=directory mode=g+rwXs
   tags: tarzan
 
 - name: download luarocks archive
@@ -55,7 +60,12 @@
   tags: tarzan
 
 - name: unpack luarocks to destination
-  unarchive: src="{{ luarocks_dest }}/{{ luarocks_file }}" dest={{ luarocks_dest }}/ copy=no creates={{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks
+  unarchive: 
+    src: "{{ luarocks_dest }}/{{ luarocks_file }}" 
+    dest: "{{ luarocks_dest }}"
+    copy: no 
+    creates: "{{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks"
+    mode: g+rwX,o+rX
   tags: tarzan
 
 - name: configure luarocks
@@ -73,7 +83,7 @@
   tags: tarzan 
 
 - name: create openssl destination directory
-  file: path={{ openssl_dest }} state=directory mode=g+s
+  file: path={{ openssl_dest }} state=directory mode=g+rwXs
   tags: tarzan
 
 - name: download openssl archive
@@ -83,11 +93,16 @@
   tags: tarzan
 
 - name: unpack openssl to destination
-  unarchive: src="{{ openssl_dest }}/{{ openssl_file }}" dest={{ openssl_dest }}/ copy=no creates={{ openssl_dest }}/{{ openssl_version }}/bin/openssl
+  unarchive: 
+    src: "{{ openssl_dest }}/{{ openssl_file }}" 
+    dest: "{{ openssl_dest }}"
+    copy: no 
+    creates: "{{ openssl_dest }}/{{ openssl_version }}/bin/openssl"
+    mode: g+rwX,o+rX
   tags: tarzan
 
 - name: create openresty destination directory
-  file: path={{ openresty_dest }} state=directory mode=g+s
+  file: path={{ openresty_dest }} state=directory mode=g+rwXs
   tags: tarzan
 
 - name: download openresty archive
@@ -97,7 +112,12 @@
   tags: tarzan
 
 - name: unpack openresty to destination
-  unarchive: src="{{ openresty_dest }}/{{ openresty_file }}" dest={{ openresty_dest }}/ copy=no creates={{ openresty_dest }}/{{ openresty_version }}/bin/resty
+  unarchive: 
+    src: "{{ openresty_dest }}/{{ openresty_file }}" 
+    dest: "{{ openresty_dest }}"
+    copy: no 
+    creates: "{{ openresty_dest }}/{{ openresty_version }}/bin/resty"
+    mode: g+rwX,o+rX
   tags: tarzan
 
 - name: configure openresty
@@ -115,7 +135,7 @@
   tags: tarzan 
 
 - name: create cassandra destination directory
-  file: path={{ cassandra_dest }} state=directory mode=g+s
+  file: path={{ cassandra_dest }} state=directory mode=g+rwXs
   tags: tarzan
 
 - name: download cassandra archive
@@ -125,7 +145,12 @@
   tags: tarzan
 
 - name: unpack cassandra to destination
-  unarchive: src="{{ cassandra_dest }}/{{ cassandra_file }}" dest={{ cassandra_dest }}/ copy=no creates={{ cassandra_dest }}/{{ cassandra_version }}/bin/cassandra
+  unarchive: 
+    src: "{{ cassandra_dest }}/{{ cassandra_file }}" 
+    dest: "{{ cassandra_dest }}"
+    copy: no 
+    creates: "{{ cassandra_dest }}/{{ cassandra_version }}/bin/cassandra"
+    mode: g+rwX,o+rX
   tags: tarzan
 
 - name: symlink cassandra to install dir
@@ -173,7 +198,7 @@
   tags: tarzan
 
 - name: create serf destination directory
-  file: path={{ serf_dest }} state=directory mode=g+s
+  file: path={{ serf_dest }} state=directory mode=g+rwXs
   tags: tarzan
 
 - name: download serf archive
@@ -183,6 +208,11 @@
   tags: tarzan
 
 - name: unpack serf to destination
-  unarchive: src="{{ serf_dest }}/{{ serf_file }}" dest={{ serf_dest }}/ copy=no creates={{ serf_dest }}/{{ serf_version }}/bin/serf
+  unarchive: 
+    src: "{{ serf_dest }}/{{ serf_file }}" 
+    dest: "{{ serf_dest }}"
+    copy: no 
+    creates: "{{ serf_dest }}/{{ serf_version }}/bin/serf"
+    mode: g+rwX,o+rX
   tags: tarzan
  

--- a/roles/tarzan/tasks/dependencies.yml
+++ b/roles/tarzan/tasks/dependencies.yml
@@ -4,6 +4,7 @@
 # luarocks
 # openresty
 # cassandra
+# serf
 
 # use a loop a la http://stackoverflow.com/questions/30785281/one-loop-over-multiple-ansible-tasks ? 
 
@@ -138,6 +139,38 @@
 - name: deploy customized cassandra main conf 
   template: src="cassandra.yaml.j2" dest="{{ ngi_pipeline_conf }}/cassandra/cassandra.yaml" 
   tags: tarzan 
+
+- name: modify cassandra's environment file for proper logdir
+  lineinfile: dest="{{ ngi_pipeline_conf }}/cassandra/cassandra-env.ps1"
+              regexp=".logdir = ."
+              line='$logdir = "{{ cassandra_log_dest }}"'
+              backup=no
+  tags: tarzan
+
+- name: modify cassandra's startup script for proper logdir
+  replace: dest="{{ cassandra_dest }}/{{ cassandra_version }}/bin/cassandra"
+              regexp=".-Dcassandra.logdir=\$CASSANDRA_HOME/logs"
+              replace=" -Dcassandra.logdir={{ cassandra_log_dest }}"
+              backup=no
+  tags: tarzan
+
+- name: modify uppsala's supervisord conf to start cassandra
+  ini_file:
+    dest={{ ngi_pipeline_conf }}/supervisord_upps.conf
+    section=program:cassandra
+    option=command
+    value="cassandra -f"
+    backup=no
+  tags: tarzan
+
+- name: modify uppsala's supervisord conf to autorestart cassandra
+  ini_file:
+    dest={{ ngi_pipeline_conf }}/supervisord_upps.conf
+    section=program:cassandra
+    option=autorestart
+    value=true
+    backup=no
+  tags: tarzan
 
 - name: create serf destination directory
   file: path={{ serf_dest }} state=directory mode=g+s

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -1,7 +1,7 @@
 --- 
 
 - name: create tarzan main directory 
-  file: name={{ tarzan_dest }} state=directory mode=g+s
+  file: name={{ tarzan_dest }} state=directory mode=g+rwXs
   tags: tarzan 
 
 - include: dependencies.yml tags=tarzan
@@ -10,8 +10,8 @@
   shell: "export PATH={{ tarzan_env_path }}:$PATH && luarocks install kong {{ kong_version }}-0"
   tags: tarzan
 
-- name: add the kong paths to the user's environment via the sourceme script 
-  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
+- name: add the kong paths to funk_004's environment via the sourceme_upps script 
+  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_upps_script }}
               line='export PATH={{ tarzan_env_path }}:$PATH'
               backup=no
   tags: tarzan
@@ -28,37 +28,43 @@
               backup=no
   tags: tarzan
 
-# TODO: have a subdir for all tarzan confs? 
-
 - name: deploy config for kong
   template: src="kong.yml.j2" dest="{{ ngi_pipeline_conf }}/webproxy.yml"
   tags: tarzan
 
-- name: modify uppsala's supervisord conf to start kong
-  ini_file:
-    dest={{ ngi_pipeline_conf }}/supervisord_upps.conf
-    section=program:kong
-    option=command
-    value="kong start -c {{ ngi_pipeline_conf }}/webproxy.conf"
-    backup=no
+# FIXME: Couldn't get this to work properly with supervisord because 
+# it demands that the program under control doesn't daemonize. 
+# (The kong binary itself spawns nginx and self binaries)
+- name: modify uppsala's crontab to start kong
+  lineinfile: dest="{{ ngi_pipeline_conf }}/crontab_upps"
+              line='# restart kong if it has died for some reason'
+              backup=no
   tags: tarzan
 
-- name: modify uppsala's supervisord conf to autorestart kong
-  ini_file:
-    dest={{ ngi_pipeline_conf }}/supervisord_upps.conf
-    section=program:kong
-    option=autorestart
-    value=true
-    backup=no
-  tags: tarzan
- 
-- name: modify uppsala's supervisord conf to send appropriate stop signal to kong child procs
-  ini_file:
-    dest={{ ngi_pipeline_conf }}/supervisord_upps.conf
-    section=program:kong
-    option=stopsignal
-    value=INT
-    backup=no
+- name: modify uppsala's crontab to start kong
+  lineinfile: dest="{{ ngi_pipeline_conf }}/crontab_upps"
+              line='@reboot source $HOME/.bash_profile && kong start -c {{ ngi_pipeline_conf }}/webproxy.yml'
+              backup=no
   tags: tarzan
 
+- name: modify uppsala's crontab to start kong
+  lineinfile: dest="{{ ngi_pipeline_conf }}/crontab_upps"
+              line='38 * * * *      source $HOME/.bash_profile && kong start -c {{ ngi_pipeline_conf }}/webproxy.yml'
+              backup=no
+  tags: tarzan
 
+# This is an ugly hack that sets the permissions correctly to g+rwX,o+rX
+# for all files that is owned by the current user that is running the playbook. 
+# This is necessary because some of the "luarocks install" and "make install" 
+# commands run in this role doesn't seem to pick up on the correct umask for
+# some weird reason.
+#
+# Note that this by purpose will miss changing the permissions of files
+# owned by an other user, as we do not want to have the playbook cluttered
+# with a lot of errors when the permission change fails.
+#
+# It is therefore expected that this script will always be run when someone is 
+# running the role.
+- name: set correct file permission for everything under sw/tarzan
+  shell: "find /lupus/ngi/sw/tarzan -user `whoami` -exec chmod g+rwX,o+rX {} \\;"
+  tags: tarzan

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -34,12 +34,31 @@
   template: src="kong.yml.j2" dest="{{ ngi_pipeline_conf }}/webproxy.yml"
   tags: tarzan
 
-# TODO: Deploy a script that launches the kong and cassandra service with the correct conf file (supervisord)
-
-# TODO: Adjust the existing supervisord script instead? 
-- name: deploy supervisord script for kong
-  template: src="supervisord_kong.conf.j2" dest="{{ ngi_pipeline_conf }}/supervisord_webproxy.conf"
+- name: modify uppsala's supervisord conf to start kong
+  ini_file:
+    dest={{ ngi_pipeline_conf }}/supervisord_upps.conf
+    section=program:kong
+    option=command
+    value="kong start -c {{ ngi_pipeline_conf }}/webproxy.conf"
+    backup=no
   tags: tarzan
 
-# TODO: Update crontab so that it launches the tarzan supervisord
+- name: modify uppsala's supervisord conf to autorestart kong
+  ini_file:
+    dest={{ ngi_pipeline_conf }}/supervisord_upps.conf
+    section=program:kong
+    option=autorestart
+    value=true
+    backup=no
+  tags: tarzan
  
+- name: modify uppsala's supervisord conf to send appropriate stop signal to kong child procs
+  ini_file:
+    dest={{ ngi_pipeline_conf }}/supervisord_upps.conf
+    section=program:kong
+    option=stopsignal
+    value=INT
+    backup=no
+  tags: tarzan
+
+

--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -176,7 +176,7 @@ nginx: |
   {{user}}
   worker_processes 4;
   error_log logs/error.log error;
-  daemon on;
+  daemon off;
 
   worker_rlimit_nofile {{auto_worker_rlimit_nofile}};
 

--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -176,7 +176,7 @@ nginx: |
   {{user}}
   worker_processes 4;
   error_log logs/error.log error;
-  daemon off;
+  daemon on;
 
   worker_rlimit_nofile {{auto_worker_rlimit_nofile}};
 

--- a/roles/tarzan/templates/supervisord_kong.conf.j2
+++ b/roles/tarzan/templates/supervisord_kong.conf.j2
@@ -1,8 +1,0 @@
-[supervisord]
-logfile={{ tarzan_log_dest }}/supervisord.log
-pidfile={{ tarzan_log_dest }}/supervisord.pid
-
-[program:kong]
-command=kong start -c {{ ngi_pipeline_conf }}/webproxy.conf
-autorestart=true
-


### PR DESCRIPTION
Set the file permission correctly for everything installed under `sw/tarzan/`. A ugly hack is necessary on L68-70 in `tasks/main.yml` that sets the permissions for group and others manually, because it seems some of the installation/compilation steps doesn't respect the umask properly set (?!). This is only done on the files owned by the current user, to limit the amount of errors. So it is expected that each user that runs this role actually runs the complete role so that the permissions gets updated for all new files added. 

Installs the `serf` software that helps kong with cluster discovery. 

Setups proper logging directory for cassandra. 

Launches cassandra via Uppsala's supervisord instance, but it doesn't seem to work easily for kong due to how it spawns sub-processes (nginx + serf) + daemonizes. Instead we're launching kong manually via Uppsala's crontab. 