### PR TITLE
Cassandra 2.2.5 doesn't exist, updating to 2.2.6

### DIFF
--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -22,9 +22,9 @@ luarocks_version: 2.3.0
 luarocks_dest: "{{ tarzan_dest }}/luarocks/"
 
 # kong depends on cassandra as backend 
-cassandra_url: http://apache.mirrors.spacedump.net/cassandra/2.2.5/apache-cassandra-2.2.5-bin.tar.gz
-cassandra_file: apache-cassandra-2.2.5-bin.tar.gz
-cassandra_version: 2.2.5
+cassandra_url: http://apache.mirrors.spacedump.net/cassandra/2.2.6/apache-cassandra-2.2.6-bin.tar.gz
+cassandra_file: apache-cassandra-2.2.6-bin.tar.gz
+cassandra_version: 2.2.6
 cassandra_dest: "{{ tarzan_dest }}/cassandra/"
 
 # kong depends on the openresty nginx clone

--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -22,8 +22,8 @@ luarocks_version: 2.3.0
 luarocks_dest: "{{ tarzan_dest }}/luarocks/"
 
 # kong depends on cassandra as backend 
-cassandra_url: https://github.com/apache/cassandra/archive/cassandra-2.2.5.zip
-cassandra_file: cassandra-2.2.5.zip
+cassandra_url: http://archive.apache.org/dist/cassandra/2.2.5/apache-cassandra-2.2.5-bin.tar.gz
+cassandra_file: apache-cassandra-2.2.5-bin.tar.gz
 cassandra_version: 2.2.5
 cassandra_dest: "{{ tarzan_dest }}/cassandra/"
 

--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -22,9 +22,9 @@ luarocks_version: 2.3.0
 luarocks_dest: "{{ tarzan_dest }}/luarocks/"
 
 # kong depends on cassandra as backend 
-cassandra_url: http://apache.mirrors.spacedump.net/cassandra/2.2.6/apache-cassandra-2.2.6-bin.tar.gz
-cassandra_file: apache-cassandra-2.2.6-bin.tar.gz
-cassandra_version: 2.2.6
+cassandra_url: https://github.com/apache/cassandra/archive/cassandra-2.2.5.zip
+cassandra_file: cassandra-2.2.5.zip
+cassandra_version: 2.2.5
 cassandra_dest: "{{ tarzan_dest }}/cassandra/"
 
 # kong depends on the openresty nginx clone


### PR DESCRIPTION
Updated cassandra version since 2.2.5 doesn't exist at the source.
If you want to pull 2.2.5 from another source instead, feel free to comment.
