### PR TITLE
Force English locale to get correct decimal separator in pipeline output

### DIFF
--- a/roles/ngi_pipeline/templates/sourceme_common.sh.j2
+++ b/roles/ngi_pipeline/templates/sourceme_common.sh.j2
@@ -3,3 +3,8 @@
 
 export CHARON_BASE_URL={{ charon_base_url }}
 
+
+# Force English locale as e.g. some downstream scripts depend on the 
+# pipeline outputing data with "." as decimal output instead of Swedish ",". 
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8


### PR DESCRIPTION
Solves https://github.com/NationalGenomicsInfrastructure/irma-provision/issues/77