### PR TITLE
Support production and staging versions of Arteria services

### DIFF
--- a/install_arteria.yml
+++ b/install_arteria.yml
@@ -11,6 +11,8 @@
   vars: 
     arteria_checksum_version: v1.0.3
     arteria_checksum_environment: production
+    arteria_siswrap_version: v1.0.2
+    arteria_siswrap_environment: production 
 
   roles: 
     - { role: arteria-checksum-ws, tags: checksum-ws }

--- a/install_arteria.yml
+++ b/install_arteria.yml
@@ -3,6 +3,15 @@
 - name: deploy arteria webservices
   hosts: 127.0.0.1
   connection: local
+
+  # These values should be overriden on the command line if you want to test 
+  # a new staging version. E.g. setting arteria_checksum_environment to 
+  # "staging" and a git commit as arteria_checksum_version would deploy into 
+  # an other dir and listen on tcp port 10421 instead of 10420.
+  vars: 
+    arteria_checksum_version: v1.0.3
+    arteria_checksum_environment: production
+
   roles: 
     - { role: arteria-checksum-ws, tags: checksum-ws }
     - { role: arteria-siswrap-ws, tags: siswrap-ws }

--- a/roles/arteria-checksum-ws/defaults/main.yml
+++ b/roles/arteria-checksum-ws/defaults/main.yml
@@ -1,20 +1,28 @@
 ---
 
-# TODO: Add correct path to monitor 
-arteria_checksum_monitored_path: "/proj/{{ ngi_pipeline_upps_delivery }}/incoming"
-
-arteria_checksum_env_root: "{{ root_path }}/sw/arteria/checksum_venv"
-arteria_checksum_virtual_env_command: "/usr/bin/python /lupus/ngi/irma3/virtualenv-15.0.0/virtualenv.py"
-
-arteria_checksum_src_path: "{{ root_path }}/sw/arteria/checksum_src"
-arteria_checksum_config_root: "{{ ngi_pipeline_conf }}/arteria/checksum"
-
-arteria_checksum_cores_to_use: 8
-# NB: The log dirs need to be created manually on destination cluster. 
-arteria_checksum_md5sum_log_dir: "{{ ngi_pipeline_upps_path }}/log/arteria/checksum_md5sum"
-arteria_checksum_service_log: "{{ ngi_pipeline_upps_path }}/log/arteria/checksum-ws"
-
+# _environment can be set to e.g. "staging" on the command line. 
+# _version is then also preferably changed.
+#
+# This will set corresponding paths and use the appropriate port.  
 arteria_checksum_repo: https://github.com/arteria-project/arteria-checksum.git
 arteria_checksum_version: v1.0.3
+arteria_checksum_environment: production
 
-arteria_checksum_port: 10420
+
+# These values will be appended with production and staging specific 
+# paths in the tasks.
+#
+# NB. The log dirs need to be created manually on destination cluster. 
+arteria_checksum_monitored_path: "/proj/{{ ngi_pipeline_upps_delivery }}/incoming"
+arteria_checksum_env_root: "{{ root_path }}/sw/arteria/checksum_venv/"
+arteria_checksum_src_path: "{{ root_path }}/sw/arteria/checksum_src/"
+arteria_checksum_config_root: "{{ ngi_pipeline_conf }}/arteria/checksum/"
+arteria_checksum_md5sum_log_dir: "{{ ngi_pipeline_upps_path }}/log/arteria/checksum_md5sum/"
+arteria_checksum_service_log: "{{ ngi_pipeline_upps_path }}/log/arteria/checksum-ws/"
+
+
+arteria_checksum_port_prod: 10420
+arteria_checksum_port_stage: 10421
+arteria_checksum_cores_to_use: 8
+
+arteria_checksum_virtual_env_command: "/usr/bin/python /lupus/ngi/irma3/virtualenv-15.0.0/virtualenv.py"

--- a/roles/arteria-checksum-ws/tasks/2_install_config.yml
+++ b/roles/arteria-checksum-ws/tasks/2_install_config.yml
@@ -18,16 +18,16 @@
 
 - name: modify uppsala's supervisord conf to start arteria-checksum-ws 
   ini_file: 
-    dest={{ ngi_pipeline_conf }}/supervisord_upps.conf
-    section=program:arteria-checksum-ws
+    dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
+    section="program:arteria-checksum-ws-{{ arteria_checksum_environment }}"
     option=command
     value="{{ arteria_checksum_env_root }}/bin/checksum-ws --configroot={{ arteria_checksum_config_root }} --port={{ arteria_checksum_port }}"
     backup=no
  
 - name: modify uppsala's supervisord conf to start arteria-checksum-ws
   ini_file: 
-    dest={{ ngi_pipeline_conf }}/supervisord_upps.conf
-    section=program:arteria-checksum-ws
+    dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
+    section="program:arteria-checksum-ws-{{ arteria_checksum_environment }}"
     option=autorestart
     value=true
     backup=no

--- a/roles/arteria-checksum-ws/tasks/main.yml
+++ b/roles/arteria-checksum-ws/tasks/main.yml
@@ -8,8 +8,8 @@
     arteria_checksum_env_root: "{{ arteria_checksum_env_root }}/production/"
     arteria_checksum_src_path: "{{ arteria_checksum_src_path }}/production/"
     arteria_checksum_config_root: "{{ arteria_checksum_config_root }}/production/"
-    arteria_checksum_md5sum_log_dir: "{{ arteria_checksum_md5sum_log_dir }}/production/"
-    arteria_checksum_service_log: "{{ arteria_checksum_service_log}}/production/"
+    arteria_checksum_md5sum_log_dir: "{{ arteria_checksum_md5sum_log_dir }}/production"
+    arteria_checksum_service_log: "{{ arteria_checksum_service_log}}/production"
     arteria_checksum_port: "{{ arteria_checksum_port_prod }}"
   when: arteria_checksum_environment == "production"
 
@@ -19,8 +19,8 @@
     arteria_checksum_env_root: "{{ arteria_checksum_env_root }}/staging/"
     arteria_checksum_src_path: "{{ arteria_checksum_src_path }}/staging/"
     arteria_checksum_config_root: "{{ arteria_checksum_config_root }}/staging/"
-    arteria_checksum_md5sum_log_dir: "{{ arteria_checksum_md5sum_log_dir }}/staging/"
-    arteria_checksum_service_log: "{{ arteria_checksum_service_log}}/staging/"
+    arteria_checksum_md5sum_log_dir: "{{ arteria_checksum_md5sum_log_dir }}/staging"
+    arteria_checksum_service_log: "{{ arteria_checksum_service_log}}/staging"
     arteria_checksum_port: "{{ arteria_checksum_port_stage }}"
   when: arteria_checksum_environment == "staging"
 

--- a/roles/arteria-checksum-ws/tasks/main.yml
+++ b/roles/arteria-checksum-ws/tasks/main.yml
@@ -1,5 +1,29 @@
 ---
 
+# Set vars depending on if we're in production or staging. 
+
+# Production 
+- set_fact: 
+    arteria_checksum_monitored_path: "{{ arteria_checksum_monitored_path }}"
+    arteria_checksum_env_root: "{{ arteria_checksum_env_root }}/production/"
+    arteria_checksum_src_path: "{{ arteria_checksum_src_path }}/production/"
+    arteria_checksum_config_root: "{{ arteria_checksum_config_root }}/production/"
+    arteria_checksum_md5sum_log_dir: "{{ arteria_checksum_md5sum_log_dir }}/production/"
+    arteria_checksum_service_log: "{{ arteria_checksum_service_log}}/production/"
+    arteria_checksum_port: "{{ arteria_checksum_port_prod }}"
+  when: arteria_checksum_environment == "production"
+
+# Staging
+- set_fact:
+    arteria_checksum_monitored_path: "{{ arteria_checksum_monitored_path }}/staging/"
+    arteria_checksum_env_root: "{{ arteria_checksum_env_root }}/staging/"
+    arteria_checksum_src_path: "{{ arteria_checksum_src_path }}/staging/"
+    arteria_checksum_config_root: "{{ arteria_checksum_config_root }}/staging/"
+    arteria_checksum_md5sum_log_dir: "{{ arteria_checksum_md5sum_log_dir }}/staging/"
+    arteria_checksum_service_log: "{{ arteria_checksum_service_log}}/staging/"
+    arteria_checksum_port: "{{ arteria_checksum_port_stage }}"
+  when: arteria_checksum_environment == "staging"
+
 - include: 1_install.yml
 
 - include: 2_install_config.yml

--- a/roles/arteria-siswrap-ws/defaults/main.yml
+++ b/roles/arteria-siswrap-ws/defaults/main.yml
@@ -1,27 +1,37 @@
 ---
 
+# _environment can be set to e.g. "staging" on the command line. 
+# _version is then also preferably changed.
+#
+# This will set corresponding paths and use the appropriate port. 
+arteria_siswrap_repo: https://github.com/arteria-project/arteria-siswrap.git
+arteria_siswrap_version: v1.0.2
+arteria_siswrap_environment: production
+
 arteria_install_path: "{{ root_path }}/sw/arteria"
+
+# These values will be appended with production and staging specific
+# paths in the tasks.
+#
+# NB. The log dirs need to be created manually on destination cluster.
 arteria_siswrap_env_root: "{{ arteria_install_path }}/siswrap_venv"
+arteria_siswrap_sources_path: "{{ arteria_install_path }}/siswrap_src"
 arteria_siswrap_config_root: "{{ ngi_pipeline_conf }}/arteria/siswrap"
 arteria_siswrap_app_config: "{{ arteria_siswrap_config_root }}/app.config"
 arteria_siswrap_logger_config: "{{ arteria_siswrap_config_root }}/logger.config"
+arteria_siswrap_log: "{{ ngi_pipeline_upps_path }}/log/arteria/siswrap-ws"
+runfolder_path: "/proj/{{ ngi_pipeline_upps_delivery }}/incoming/"
 
-arteria_siswrap_port: 10430
+arteria_siswrap_port_prod: 10430
+arteria_siswrap_port_stage: 10431
 arteria_siswrap_mail_from: johan.hermansson@medsci.uu.se
 arteria_siswrap_mail_to: arteria-project@googlegroups.com
-arteria_siswrap_log: "{{ ngi_pipeline_upps_path }}/log/arteria/siswrap-ws"
-
-arteria_siswrap_sources_path: "{{ arteria_install_path }}/siswrap_src"
-arteria_siswrap_repo: https://github.com/arteria-project/arteria-siswrap.git
-arteria_siswrap_version: v1.0.2
 
 virtual_env_command: "/usr/bin/python /lupus/ngi/irma3/virtualenv-15.0.0/virtualenv.py"
 
-sisyphus_path: "{{ arteria_siswrap_env_root }}/deps/sisyphus/"
+sisyphus_path: "{{ arteria_siswrap_env_root }}/deps/sisyphus/" # set by a task
 sisyphus_git_repo: https://github.com/Molmed/sisyphus.git
 sisyphus_repo_branch: master
-
-runfolder_path: "/proj/{{ ngi_pipeline_upps_delivery }}/incoming/"
 
 # Where to install our local Perl packages
 perllib_dest: "{{ ngi_resources }}/arteria/perl"

--- a/roles/arteria-siswrap-ws/tasks/main.yml
+++ b/roles/arteria-siswrap-ws/tasks/main.yml
@@ -1,5 +1,27 @@
 ---
 
+# Production values
+- set_fact: 
+    arteria_siswrap_env_root: "{{ arteria_siswrap_env_root }}/production/"
+    arteria_siswrap_sources_path: "{{ arteria_siswrap_sources_path }}/production/"
+    arteria_siswrap_config_root: "{{ arteria_siswrap_config_root }}/production/"
+    arteria_siswrap_log: "{{ arteria_siswrap_log }}/production"
+    runfolder_path: "{{ runfolder_path }}"
+    arteria_siswrap_port: "{{ arteria_siswrap_port_prod }}"
+    sisyphus_path: "{{ arteria_siswrap_env_root }}/deps/sisyphus/"
+  when: arteria_siswrap_environment == "production"
+
+# Staging values
+- set_fact: 
+    arteria_siswrap_env_root: "{{ arteria_siswrap_env_root }}/staging/"
+    arteria_siswrap_sources_path: "{{ arteria_siswrap_sources_path }}/staging/"
+    arteria_siswrap_config_root: "{{ arteria_siswrap_config_root }}/staging/"
+    arteria_siswrap_log: "{{ arteria_siswrap_log }}/staging"
+    runfolder_path: "{{ runfolder_path }}/staging/"
+    arteria_siswrap_port: "{{ arteria_siswrap_port_stage }}"
+    sisyphus_path: "{{ arteria_siswrap_env_root }}/deps/sisyphus/"
+  when: arteria_siswrap_environment == "staging"
+
 - include: install.yml
 - include: sisyphus.yml
 
@@ -12,18 +34,18 @@
 - name: deploying arteria-siswrap app config
   template:
     src: siswrap_app.config.j2
-    dest: "{{ arteria_siswrap_app_config }}"
+    dest: "{{ arteria_siswrap_config_root }}/app.config"
 
 - name: deploying arteria-siswrap logger config
   template:
     src: siswrap_logger.config.j2
-    dest: "{{ arteria_siswrap_logger_config }}"
+    dest: "{{ arteria_siswrap_config_root }}/logger.config"
 
 # TODO: Perl that launches needs to have the correct PERL5LIB setup. 
 - name: modify uppsala's supervisord conf to start arteria-siswrap-ws 
   ini_file: 
     dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
-    section=program:arteria-siswrap-ws
+    section="program:arteria-siswrap-ws-{{ arteria_siswrap_environment }}"
     option=command
     value="{{ arteria_siswrap_env_root }}/bin/siswrap-ws --configroot={{ arteria_siswrap_config_root }} --port={{ arteria_siswrap_port }}"
     backup=no
@@ -31,7 +53,7 @@
 - name: modify uppsala's supervisord conf to autostart arteria-siswrap-ws
   ini_file: 
     dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
-    section=program:arteria-siswrap-ws
+    section="program:arteria-siswrap-ws-{{ arteria_siswrap_environment }}"
     option=autorestart
     value=true
     backup=no

--- a/roles/arteria-siswrap-ws/tasks/sisyphus.yml
+++ b/roles/arteria-siswrap-ws/tasks/sisyphus.yml
@@ -3,6 +3,10 @@
 # FIXME: One system dependency that is missing atm is PyXML. 
 # See if everything works well anyway. 
 
+# Override the value from defaults so we get prod/stage specific path
+- set_fact: 
+    sisyphus_path: "{{ arteria_siswrap_env_root }}/deps/sisyphus/"
+
 - name: create arteria perllib dir 
   file: path="{{ perllib_dest }}" state=directory mode=g+s 
 

--- a/roles/arteria-siswrap-ws/templates/siswrap_app.config.j2
+++ b/roles/arteria-siswrap-ws/templates/siswrap_app.config.j2
@@ -1,6 +1,6 @@
 ---
 
-port: {{  arteria_siswrap_port }}
+port: {{ arteria_siswrap_port }}
 sender: {{ arteria_siswrap_mail_from }}
 receiver: {{ arteria_siswrap_mail_to }}
 report_bin: {{ arteria_siswrap_env_root }}/deps/sisyphus/sisyphus-latest/quickReport.pl


### PR DESCRIPTION
Sets up production and staging specific paths and values in the form of `/lupus/ngi/conf/arteria/{checksum,siswrap}/{production,staging}` and `/lupus/ngi/sw/arteria/{checksum,siswrap}_{src,venv}/{production,staging}`, and updates Uppsala's `supervisord.conf` to listen on different ports depending on environment. 

What version to install is controlled via the vars `arteria_checksum_environment` and `arteria_checksum_version` (and corresponding for `siswrap`). Can be overridden on the command line when the operator wants to install a new version into staging e.g. 