### PR TITLE
NGI Reports texlive installation

### DIFF
--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -7,4 +7,3 @@ ngi_visual_version: 1aee395644551c408219618f35975db24b8dedc7
 texLive_file: install-tl-unx.tar.gz 
 texLive_url: "http://mirror.ctan.org/systems/texlive/tlnet/{{ texLive_file }}"
 texLive_dest: "{{ ngi_resources }}/texLive/"
-texLive_path: "{{ texLive_dest }}/texLive"

--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -4,6 +4,6 @@ ngi_visual_repo: https://github.com/NationalGenomicsInfrastructure/ngi_visualiza
 ngi_visual_dest: "{{ root_path }}/sw//ngi_visualization"
 ngi_visual_version: 1aee395644551c408219618f35975db24b8dedc7
 
-texLive_file install-tl-unx.tar.gz
+texLive_file: "install-tl-unx.tar.gz"
 texLive_url: "http://mirror.ctan.org/systems/texlive/tlnet/{{ texLive_file }}"
 texLive_dest: "{{ ngi_resources }}/texLive/"

--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -4,6 +4,6 @@ ngi_visual_repo: https://github.com/NationalGenomicsInfrastructure/ngi_visualiza
 ngi_visual_dest: "{{ root_path }}/sw//ngi_visualization"
 ngi_visual_version: 1aee395644551c408219618f35975db24b8dedc7
 
-texLive_file: install-tl-unx.tar.gz 
+texLive_file install-tl-unx.tar.gz
 texLive_url: "http://mirror.ctan.org/systems/texlive/tlnet/{{ texLive_file }}"
 texLive_dest: "{{ ngi_resources }}/texLive/"

--- a/roles/ngi_reports/files/make_report.sh
+++ b/roles/ngi_reports/files/make_report.sh
@@ -5,8 +5,8 @@ function make_report {
       fn=${f%.md}
       echo "Converting ${f}.."
       PD_DIR=${ngi_reports_dir}/data/pandoc_templates
-      ${PD_DIR}/pandoc --standalone --section-divs ${fn}.md -o ${fn}.html --template=${PD_DIR}/html_pandoc.html --default-image-extension=png --filter ${PD_DIR}/pandoc_filters.py -V template_dir=${PD_DIR}/ 
-      ${PD_DIR}/pandoc --standalone ${fn}.md -o ${fn}.pdf --template=${PD_DIR}/latex_pandoc.tex --latex-engine=xelatex --default-image-extension=pdf --filter ${PD_DIR}/pandoc_filters.py -V template_dir=${PD_DIR}/ 
+      pandoc --standalone --section-divs ${fn}.md -o ${fn}.html --template=${PD_DIR}/html_pandoc.html --default-image-extension=png --filter ${PD_DIR}/pandoc_filters.py -V template_dir=${PD_DIR}/ 
+      pandoc --standalone ${fn}.md -o ${fn}.pdf --template=${PD_DIR}/latex_pandoc.tex --latex-engine=xelatex --default-image-extension=pdf --filter ${PD_DIR}/pandoc_filters.py -V template_dir=${PD_DIR}/ 
     done
 }
 export -f make_report

--- a/roles/ngi_reports/tasks/dependencies.yml
+++ b/roles/ngi_reports/tasks/dependencies.yml
@@ -2,18 +2,14 @@
 ##Plausible TODOs:
 # Install Helvetica Neue and Consolas from ngi_reports/data/pandoc_templates/assets/fonts/
 
-- stat: path="{{ texLive_dest }}/tlpkg/texlive.profile"
-  register: texlive_installed
-
 - name: Create TeXLive destination
   file: path={{ texLive_dest }} state=directory mode=g+rwxs
   tags: ngi_reports
 
-- name: Download TeXLive (Skipped if installed)
+- name: Download TeXLive
   get_url:
     url: "{{ texLive_url }}"
     dest: "{{ texLive_dest }}/src/{{ texLive_file }}"
-    when: not texlive_installed
     mode: g+rw
   tags: ngi_reports
 
@@ -29,6 +25,9 @@
 - name: Copy TexLive profile
   template: src="texlive.profile.j2" dest="{{ ngi_pipeline_conf }}/texlive.profile" mode=0775
   tags: ngi_reports 
+
+- stat: path="{{ texLive_dest }}/tlpkg/texlive.profile"
+  register: texlive_installed
 
 - name: Install TeXLive (Skipped if installed)
   shell: "./install-tl --profile={{ ngi_pipeline_conf }}/texlive.profile"

--- a/roles/ngi_reports/tasks/dependencies.yml
+++ b/roles/ngi_reports/tasks/dependencies.yml
@@ -2,21 +2,19 @@
 ##Plausible TODOs:
 # Install Helvetica Neue and Consolas from ngi_reports/data/pandoc_templates/assets/fonts/
 
-- name: Check for existing TeXLive installation
-  stat: path="{{ texLive_dest }}/tlpkg/texlive.profile"
+- stat: path="{{ texLive_dest }}/tlpkg/texlive.profile"
   register: texlive_installed
 
 - name: Create TeXLive destination
   file: path={{ texLive_dest }} state=directory mode=g+rwxs
-  when: not texlive_installed
   tags: ngi_reports
 
-- name: Download TeXLive
+- name: Download TeXLive (Skipped if installed)
   get_url:
     url: "{{ texLive_url }}"
     dest: "{{ texLive_dest }}/src/{{ texLive_file }}"
+    when: not texlive_installed
     mode: g+rw
-  when: not texlive_installed
   tags: ngi_reports
 
 - name: Unpack TeXLive
@@ -26,15 +24,13 @@
     copy: no
     creates: "{{ texLive_dest }}/src/LICENSE"
     mode: g+rw
-  when: not texlive_installed
   tags: ngi_reports
 
 - name: Copy TexLive profile
   template: src="texlive.profile.j2" dest="{{ ngi_pipeline_conf }}/texlive.profile" mode=0775
-  when: not texlive_installed
   tags: ngi_reports 
 
-- name: Install TeXLive (takes forever)
+- name: Install TeXLive (Skipped if installed)
   shell: "./install-tl --profile={{ ngi_pipeline_conf }}/texlive.profile"
   args:
     chdir: "{{ texLive_dest }}"
@@ -45,7 +41,6 @@
   lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
               line='export PATH={{ texLive_dest }}/bin/x86_64-linux:$PATH'
               backup=no
-  when: not texlive_installed
   tags: ngi_reports
 
 - name: Fetch ngi_visualizations from GitHub

--- a/roles/ngi_reports/tasks/dependencies.yml
+++ b/roles/ngi_reports/tasks/dependencies.yml
@@ -6,6 +6,10 @@
   file: path={{ texLive_dest }} state=directory mode=g+rwxs
   tags: ngi_reports
 
+- name: Create TexLive src folder (seperate to honor permissions)
+  file: path={{ texLive_dest }}/src state=directory mode=g+rwxs
+  tags: ngi_reports
+
 - name: Download TeXLive
   get_url:
     url: "{{ texLive_url }}"
@@ -18,21 +22,21 @@
     src: "{{ texLive_dest }}/src/{{ texLive_file }}"
     dest: "{{ texLive_dest }}"
     copy: no
-    creates: "{{ texLive_dest }}/src/LICENSE"
+    creates: "{{ texLive_dest }}/src/install-tl-*/LICENSE"
     mode: g+rw
   tags: ngi_reports
 
 - name: Copy TexLive profile
-  template: src="texlive.profile.j2" dest="{{ ngi_pipeline_conf }}/texlive.profile" mode=0775
+  template: src="texlive.profile.j2" dest="{{ ngi_pipeline_conf }}/texlive.profile" mode=0664
   tags: ngi_reports 
 
-- stat: path="{{ texLive_dest }}/tlpkg/texlive.profile"
+- stat: path="{{ texLive_dest }}/src/install-tl-*/tlpkg/texlive.profile"
   register: texlive_installed
 
-- name: Install TeXLive (Skipped if installed)
+- name: Install TeXLive (Takes a long time)
   shell: "./install-tl --profile={{ ngi_pipeline_conf }}/texlive.profile"
   args:
-    chdir: "{{ texLive_dest }}"
+    chdir: "{{ texLive_dest }}/src/install-tl-*/"
   when: not texlive_installed
   tags: ngi_reports
 

--- a/roles/ngi_reports/tasks/dependencies.yml
+++ b/roles/ngi_reports/tasks/dependencies.yml
@@ -68,9 +68,9 @@
   copy: src=make_report.sh dest="{{ ngi_resources }}/make_report.sh" mode=0775
   tags: ngi_reports 
 
-- name: Add Pandoc fix to alias
-  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
-              line="alias ngi_reports='ngi_reports --pandoc_binary'"
-              backup=no
-  tags: ngi_reports
+#- name: Add Pandoc fix to alias
+#  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
+#              line="alias ngi_reports='ngi_reports --pandoc_binary'"
+#              backup=no
+#  tags: ngi_reports
 

--- a/roles/ngi_reports/tasks/dependencies.yml
+++ b/roles/ngi_reports/tasks/dependencies.yml
@@ -22,7 +22,7 @@
     src: "{{ texLive_dest }}/src/{{ texLive_file }}"
     dest: "{{ texLive_dest }}"
     copy: no
-    creates: "{{ texLive_dest }}/src/install-tl-*/LICENSE"
+    creates: "{{ texLive_dest }}/src/install-tl-*/LICENSE.TL"
     mode: g+rw
   tags: ngi_reports
 
@@ -30,14 +30,11 @@
   template: src="texlive.profile.j2" dest="{{ ngi_pipeline_conf }}/texlive.profile" mode=0664
   tags: ngi_reports 
 
-- stat: path="{{ texLive_dest }}/src/install-tl-*/tlpkg/texlive.profile"
-  register: texlive_installed
-
 - name: Install TeXLive (Takes a long time)
   shell: "./install-tl --profile={{ ngi_pipeline_conf }}/texlive.profile"
   args:
     chdir: "{{ texLive_dest }}/src/install-tl-*/"
-  when: not texlive_installed
+    creates: "{{ texLive_dest }}/tlpkg/texlive.profile"
   tags: ngi_reports
 
 - name: Append TexLive (XeLaTeX) to $PATH via sourceme

--- a/roles/ngi_reports/tasks/dependencies.yml
+++ b/roles/ngi_reports/tasks/dependencies.yml
@@ -2,30 +2,50 @@
 ##Plausible TODOs:
 # Install Helvetica Neue and Consolas from ngi_reports/data/pandoc_templates/assets/fonts/
 
-- name: Create TeXLive destination 
+- name: Check for existing TeXLive installation
+  stat: path="{{ texLive_dest }}/tlpkg/texlive.profile"
+  register: texlive_installed
+
+- name: Create TeXLive destination
   file: path={{ texLive_dest }} state=directory mode=g+rwxs
+  when: not texlive_installed
   tags: ngi_reports
 
 - name: Download TeXLive
   get_url:
     url: "{{ texLive_url }}"
-    dest: "{{ texLive_dest }}/{{ texLive_file }}"
+    dest: "{{ texLive_dest }}/src/{{ texLive_file }}"
     mode: g+rw
+  when: not texlive_installed
   tags: ngi_reports
 
 - name: Unpack TeXLive
   unarchive:
-    src: "{{ texLive_dest }}/{{ texLive_file }}"
+    src: "{{ texLive_dest }}/src/{{ texLive_file }}"
     dest: "{{ texLive_dest }}"
     copy: no
-    creates: "{{ texLive_path }}/LICENSE"
+    creates: "{{ texLive_dest }}/src/LICENSE"
     mode: g+rw
+  when: not texlive_installed
   tags: ngi_reports
 
-- name: Append TexLive to $PATH via sourceme
+- name: Copy TexLive profile
+  template: src="texlive.profile.j2" dest="{{ ngi_pipeline_conf }}/texlive.profile" mode=0775
+  when: not texlive_installed
+  tags: ngi_reports 
+
+- name: Install TeXLive (takes forever)
+  shell: "./install-tl --profile={{ ngi_pipeline_conf }}/texlive.profile"
+  args:
+    chdir: "{{ texLive_dest }}"
+  when: not texlive_installed
+  tags: ngi_reports
+
+- name: Append TexLive (XeLaTeX) to $PATH via sourceme
   lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
-              line='export PATH={{ texLive_path }}:$PATH'
+              line='export PATH={{ texLive_dest }}/bin/x86_64-linux:$PATH'
               backup=no
+  when: not texlive_installed
   tags: ngi_reports
 
 - name: Fetch ngi_visualizations from GitHub
@@ -63,11 +83,11 @@
 
 ###END STOCKHOLM SPECIFIC
 
-#NOTE: WORKAROUND MAY NOT BE REQUIRED, BUT LIKELY SO.
 - name: Copy Pandoc fix
-  copy: src=make_report.sh dest="{{ ngi_resources }}/make_report.sh" mode=0775
+  template: src=make_report.sh.j2 dest="{{ ngi_resources }}/make_report.sh" mode=0775
   tags: ngi_reports 
 
+#Working with UPPMAX Pandoc. This isn't required until further notice
 #- name: Add Pandoc fix to alias
 #  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
 #              line="alias ngi_reports='ngi_reports --pandoc_binary'"

--- a/roles/ngi_reports/tasks/main.yml
+++ b/roles/ngi_reports/tasks/main.yml
@@ -14,7 +14,6 @@
   shell: "{{ ngi_pipeline_venv }}/bin/pip install -r {{ ngi_reports_dest }}/requirements.txt"
   tags: ngi_reports
 
-#-e works similar to setup.py develop. Necessary for some hardcoded dependencies.
 - name: Install ngi_reports
   shell: "{{ ngi_pipeline_venv }}/bin/pip install -e ."
   args:

--- a/roles/ngi_reports/templates/make_report.sh.j2
+++ b/roles/ngi_reports/templates/make_report.sh.j2
@@ -4,7 +4,7 @@ function make_report {
     for f in "$@"; do
       fn=${f%.md}
       echo "Converting ${f}.."
-      PD_DIR=${{ ngi_reports_dest }}/data/pandoc_templates
+      PD_DIR={{ ngi_reports_dest }}/data/pandoc_templates
       pandoc --standalone --section-divs ${fn}.md -o ${fn}.html --template=${PD_DIR}/html_pandoc.html --default-image-extension=png --filter ${PD_DIR}/pandoc_filters.py -V template_dir=${PD_DIR}/ 
       pandoc --standalone ${fn}.md -o ${fn}.pdf --template=${PD_DIR}/latex_pandoc.tex --latex-engine=xelatex --default-image-extension=pdf --filter ${PD_DIR}/pandoc_filters.py -V template_dir=${PD_DIR}/ 
     done

--- a/roles/ngi_reports/templates/make_report.sh.j2
+++ b/roles/ngi_reports/templates/make_report.sh.j2
@@ -4,7 +4,7 @@ function make_report {
     for f in "$@"; do
       fn=${f%.md}
       echo "Converting ${f}.."
-      PD_DIR=${ngi_reports_dir}/data/pandoc_templates
+      PD_DIR=${{ ngi_reports_dest }}/data/pandoc_templates
       pandoc --standalone --section-divs ${fn}.md -o ${fn}.html --template=${PD_DIR}/html_pandoc.html --default-image-extension=png --filter ${PD_DIR}/pandoc_filters.py -V template_dir=${PD_DIR}/ 
       pandoc --standalone ${fn}.md -o ${fn}.pdf --template=${PD_DIR}/latex_pandoc.tex --latex-engine=xelatex --default-image-extension=pdf --filter ${PD_DIR}/pandoc_filters.py -V template_dir=${PD_DIR}/ 
     done

--- a/roles/ngi_reports/templates/texlive.profile.j2
+++ b/roles/ngi_reports/templates/texlive.profile.j2
@@ -1,0 +1,76 @@
+selected_scheme scheme-full
+TEXDIR {{ texLive_dest }}
+TEXMFCONFIG $TEXMFSYSCONFIG
+TEXMFHOME $TEXMFLOCAL
+TEXMFLOCAL {{ texLive_dest }}/texmf-local
+TEXMFSYSCONFIG {{ texLive_dest }}/texmf-config
+TEXMFSYSVAR {{ texLive_dest }}/texmf-var
+TEXMFVAR $TEXMFSYSVAR
+binary_x86_64-linux 1
+collection-basic 1
+collection-bibtexextra 1
+collection-binextra 1
+collection-context 1
+collection-fontsextra 1
+collection-fontsrecommended 1
+collection-fontutils 1
+collection-formatsextra 1
+collection-games 1
+collection-genericextra 1
+collection-genericrecommended 1
+collection-htmlxml 1
+collection-humanities 1
+collection-langafrican 1
+collection-langarabic 1
+collection-langchinese 1
+collection-langcjk 1
+collection-langcyrillic 1
+collection-langczechslovak 1
+collection-langenglish 1
+collection-langeuropean 1
+collection-langfrench 1
+collection-langgerman 1
+collection-langgreek 1
+collection-langindic 1
+collection-langitalian 1
+collection-langjapanese 1
+collection-langkorean 1
+collection-langother 1
+collection-langpolish 1
+collection-langportuguese 1
+collection-langspanish 1
+collection-latex 1
+collection-latexextra 1
+collection-latexrecommended 1
+collection-luatex 1
+collection-mathextra 1
+collection-metapost 1
+collection-music 1
+collection-omega 1
+collection-pictures 1
+collection-plainextra 1
+collection-pstricks 1
+collection-publishers 1
+collection-science 1
+collection-texworks 1
+collection-xetex 1
+in_place 0
+option_adjustrepo 1
+option_autobackup 1
+option_backupdir tlpkg/backups
+option_desktop_integration 
+option_doc 1
+option_file_assocs 
+option_fmt 1
+option_letter 0
+option_menu_integration 
+option_path 
+option_post_code 1
+option_src 1
+option_sys_bin /usr/local/bin
+option_sys_info /usr/local/share/info
+option_sys_man /usr/local/share/man
+option_w32_multi_user 1
+option_write18_restricted 1
+portable 1
+


### PR DESCRIPTION
TexLive wasn't properly installed in the past. This was ignored as NGI Reports had ten other things not making it functional. This update makes sure TexLive is actually installed and used.

Feel free to verify this a bit extra. The installation takes forever, so I've only quickly verified it once.