### PR TITLE
Install some CPAN modules manually via cpanm 

### DIFF
--- a/roles/arteria-siswrap-ws/defaults/main.yml
+++ b/roles/arteria-siswrap-ws/defaults/main.yml
@@ -36,3 +36,7 @@ sisyphus_repo_branch: master
 # Where to install our local Perl packages
 perllib_dest: "{{ ngi_resources }}/arteria/perl"
 
+# Special $PATH variable for running some manual cpanm commands 
+# which otherwie include the wrong headers and libs (e.g. from anaconda, 
+# which is on the path, instead of the system libs). 
+cpanm_env: /lupus/ngi/irma3/ansible-env/bin/:/usr/bin:/bin

--- a/roles/arteria-siswrap-ws/tasks/sisyphus.yml
+++ b/roles/arteria-siswrap-ws/tasks/sisyphus.yml
@@ -13,10 +13,10 @@
 - name: install File::NFSLock
   cpanm: name=File::NFSLock locallib="{{ perllib_dest }}"
 
-# Don't run the tests for this, as it seems to complain about a 
-# minor version missmatch for libxml2. 
 - name: install XML::LibXML
-  cpanm: name=XML::LibXML locallib="{{ perllib_dest }}" notest=yes
+  shell: "PATH={{ cpanm_env }} cpanm -l {{ perllib_dest }} XML::LibXML"
+  args: 
+    creates: "{{ perllib_dest }}/lib/perl5/*/XML/LibXML.pm"
 
 - name: install XML::LibXML::Common
   cpanm: name=XML::LibXML::Common locallib="{{ perllib_dest }}"
@@ -39,10 +39,10 @@
 - name: install PDL
   cpanm: name=PDL locallib="{{ perllib_dest }}"
 
-# Don't run tests for this, complains about minor version 
-# mismatch for libmxl2
 - name: install XML::LibXSLT
-  cpanm: name=XML::LibXSLT locallib="{{ perllib_dest }}" notest=yes
+  shell: "PATH={{ cpanm_env }} cpanm -l {{ perllib_dest }} XML::LibXSLT"
+  args:
+    creates: "{{ perllib_dest }}/lib/perl5/*/XML/LibXSLT.pm"
 
 - name: create sisyphus code folder
   file: path="{{ sisyphus_path }}" state=directory mode=g+s

--- a/roles/arteria-siswrap-ws/tasks/sisyphus.yml
+++ b/roles/arteria-siswrap-ws/tasks/sisyphus.yml
@@ -16,7 +16,7 @@
 - name: install XML::LibXML
   shell: "PATH={{ cpanm_env }} cpanm -l {{ perllib_dest }} XML::LibXML"
   args: 
-    creates: "{{ perllib_dest }}/lib/perl5/*/XML/LibXML.pm"
+    creates: "{{ perllib_dest }}/lib/perl5/x86_64-linux-thread-multi/XML/LibXML.pm"
 
 - name: install XML::LibXML::Common
   cpanm: name=XML::LibXML::Common locallib="{{ perllib_dest }}"
@@ -42,7 +42,7 @@
 - name: install XML::LibXSLT
   shell: "PATH={{ cpanm_env }} cpanm -l {{ perllib_dest }} XML::LibXSLT"
   args:
-    creates: "{{ perllib_dest }}/lib/perl5/*/XML/LibXSLT.pm"
+    creates: "{{ perllib_dest }}/lib/perl5/x86_64-linux-thread-multi/XML/LibXSLT.pm"
 
 - name: create sisyphus code folder
   file: path="{{ sisyphus_path }}" state=directory mode=g+s


### PR DESCRIPTION
Needed so we can set some appropriate env vars ($PATH) before running cpanm. By removing anaconda from $PATH cpanm will not pick up the version of libxml2.so that it bundles, which otherwise conflicts with the system installed version under /usr/lib64. 