### PR TITLE
New ngi_reports version, multiqc config separation

### DIFF
--- a/roles/multiqc/tasks/main.yml
+++ b/roles/multiqc/tasks/main.yml
@@ -43,6 +43,6 @@
               line="alias multiqc='multiqc -c {{ ngi_pipeline_conf }}/multiqc_{{ item.site }}_config.yml'"
               backup=no
   with_items:
-  - { site: "sthlm", script: {{ bash_env_sthlm_script }} }
-  - { site: "upps", script: {{ bash_env_upps_script }} }
+  - { site: "sthlm", script: "{{ bash_env_sthlm_script }}" }
+  - { site: "upps", script: "{{ bash_env_upps_script }}" }
   tags: multiqc

--- a/roles/multiqc/tasks/main.yml
+++ b/roles/multiqc/tasks/main.yml
@@ -20,7 +20,9 @@
   tags: multiqc
 
 - name: Install MultiQC NGI submodule
-  shell: "cd {{ multiqc_ngi_dest }} && {{ ngi_pipeline_venv }}/bin/pip install ."
+  shell: "{{ ngi_pipeline_venv }}/bin/pip install ."
+  args:
+    chdir: "{{ multiqc_ngi_dest }}"
   tags: multiqc
 
 - name: Add statusDB envvar to sourceme
@@ -29,12 +31,18 @@
               backup=no
   tags: multiqc
 
-- name: Deploy multiqc config
-  copy: src="multiqc_config.yml" dest="{{ ngi_pipeline_conf }}"
+- name: Deploy multiqc configs
+  template: src="multiqc_config.yml.j2" dest="{{ ngi_pipeline_conf }}/multiqc_{{ item.site }}_config.yml"
+  with_items: 
+  - { site: "sthlm", ngi_hooks: "True"}
+  - { site: "upps", ngi_hooks: "False"}
   tags: multiqc
 
 - name: Force multiqc to autorun config
-  lineinfile: dest="{{ ngi_pipeline_conf }}/{{ bash_env_script }}"
-              line="alias multiqc='multiqc -c {{ ngi_pipeline_conf }}/multiqc_config.yml'"
+  lineinfile: dest="{{ ngi_pipeline_conf }}/{{ item.script }}"
+              line="alias multiqc='multiqc -c {{ ngi_pipeline_conf }}/multiqc_{{ item.site }}_config.yml'"
               backup=no
+  with_items:
+  - { site: "sthlm", script: {{ bash_env_sthlm_script }} }
+  - { site: "upps", script: {{ bash_env_upps_script }} }
   tags: multiqc

--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -1,4 +1,4 @@
 ---
 no_version_check: True
 push_statusdb: False
-disable_ngi: False
+"disable_ngi: {{ item.ngi_hooks }}"

--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -1,4 +1,4 @@
 ---
 no_version_check: True
 push_statusdb: False
-"disable_ngi: {{ item.ngi_hooks }}"
+disable_ngi: {{ item.ngi_hooks }}

--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ngi_reports_repo: https://github.com/NationalGenomicsInfrastructure/ngi_reports.git
 ngi_reports_dest: "{{ root_path }}/sw/ngi_reports"
-ngi_reports_version: f65afd5cda2916e5df07604c19b9fc5a52ed375e
+ngi_reports_version: 000b5cde78a0fdae5d7864033c2bd6a319bcc33b
 ngi_reports_log: "/log/ngi_reports.log"
 ngi_reports_log_sthlm: "{{ ngi_pipeline_sthlm_path }}/{{ ngi_reports_log }}"
 ngi_reports_log_upps: "{{ ngi_pipeline_upps_path }}/{{ ngi_reports_log }}"


### PR DESCRIPTION
Due to the NGI submodule of MultiQC causing problems for Uppsala, the config for MultiQC has now been separated into two.
NGI Reports has also been updated to fix an invalid libprep issue.