### PR TITLE
Install latest version of arteria-siswrap into production

### DIFF
--- a/install_arteria.yml
+++ b/install_arteria.yml
@@ -11,7 +11,7 @@
   vars: 
     arteria_checksum_version: v1.0.3
     arteria_checksum_environment: production
-    arteria_siswrap_version: v1.0.2
+    arteria_siswrap_version: v1.1.0
     arteria_siswrap_environment: production 
 
   roles: 


### PR DESCRIPTION
Includes support for running the Sisyphus aeacus-report and aeacus-stats scripts via API wrappers. 