### PR TITLE
Tarzan: use self signed SSL cert valid for 4 years

### DIFF
--- a/roles/tarzan/README.md
+++ b/roles/tarzan/README.md
@@ -19,6 +19,12 @@ There is no specific backup of Cassandra at the moment. And the serf traffic (ov
 
 # Usage 
 
+## Configuring self signed SSL cert
+
+On Irma run `openssl req -x509 -newkey rsa:2048 -keyout tarzan_key.pem -out tarzan_cert.pem -days 1460 -nodes` to generate a self signed server SSL key and cert for the Irma webproxy, valid for 4 years. Put `tarzan_key.pem` and `tarzan_cert.pem` under `/lupus/ngi/irma3/deploy/files` so that they can be picked up by the Tarzan role. 
+
+(One can then add the contents of `tarzan_cert.pem` to the client's CA bundle if one want to get rid of certificate warnings. E.g. some clients (like Stackstorm) use the Mozilla CA bundle in the Python library `requests`, which can usually be found under a path similar to `..../python2.7/site-packages/requests/cacert.pem`.)
+
 ## Adding a downstream API to Kong 
 
 As an example, we will here demonstrate how to proxy the ngi_pipeline web API for Uppsala, as well as adding an authentication layer on top. 

--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -1,6 +1,7 @@
 --- 
 
 tarzan_dest: "{{ root_path }}/sw/tarzan/"
+tarzan_conf: "{{ ngi_pipeline_conf }}/tarzan/"
 
 ## Paths for all sw to download and later build 
 

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -3,6 +3,9 @@
 - name: create tarzan main directory 
   file: name={{ tarzan_dest }} state=directory mode=g+rwXs
 
+- name: create tarzan conf dir 
+  file: name={{ tarzan_conf }} state=directory mode=g+rwXs
+
 - include: dependencies.yml 
 
 - name: install kong via luarocks
@@ -24,7 +27,13 @@
               backup=no
 
 - name: deploy config for kong
-  template: src="kong.yml.j2" dest="{{ ngi_pipeline_conf }}/webproxy.yml"
+  template: src="kong.yml.j2" dest="{{ tarzan_conf }}/webproxy.yml"
+
+- name: deploy ssl cert for kong
+  copy: src="tarzan_cert.pem" dest="{{ tarzan_conf }}/tarzan_cert.pem"
+
+- name: deploy ssl key for kong 
+  copy: src="tarzan_key.pem" dest="{{ tarzan_conf }}/tarzan_key.pem"
 
 # FIXME: Couldn't get this to work properly with supervisord because 
 # it demands that the program under control doesn't daemonize. 
@@ -36,11 +45,10 @@
 
 - name: modify uppsala's crontab to start kong
   lineinfile: dest="{{ ngi_pipeline_conf }}/crontab_upps"
-              line='@reboot source $HOME/.bash_profile && kong start -c {{ ngi_pipeline_conf }}/webproxy.yml'
+              line='@reboot source $HOME/.bash_profile && kong start -c {{ tarzan_conf }}/webproxy.yml'
               backup=no
 
 - name: modify uppsala's crontab to start kong
   lineinfile: dest="{{ ngi_pipeline_conf }}/crontab_upps"
-              line='38 * * * *      source $HOME/.bash_profile && kong start -c {{ ngi_pipeline_conf }}/webproxy.yml'
+              line='38 * * * *      source $HOME/.bash_profile && kong start -c {{ tarzan_conf }}/webproxy.yml'
               backup=no
-

--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -56,8 +56,8 @@ cluster_listen_rpc: "127.0.0.1:7373"
 
 ######
 ## The path to the SSL certificate and key that Kong will use when listening on the `https` port.
-# ssl_cert_path: /path/to/certificate.pem
-# ssl_key_path: /path/to/certificate.key
+ssl_cert_path: {{ ngi_pipeline_conf }}/tarzan/tarzan_cert.pem
+ssl_key_path: {{ ngi_pipeline_conf }}/tarzan/tarzan_key.pem
 
 ######
 ## Specify how Kong performs DNS resolution (in the `dns_resolvers_available` property) you want to use.

--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -56,8 +56,8 @@ cluster_listen_rpc: "127.0.0.1:7373"
 
 ######
 ## The path to the SSL certificate and key that Kong will use when listening on the `https` port.
-ssl_cert_path: {{ ngi_pipeline_conf }}/tarzan/tarzan_cert.pem
-ssl_key_path: {{ ngi_pipeline_conf }}/tarzan/tarzan_key.pem
+ssl_cert_path: {{ tarzan_conf }}/tarzan/tarzan_cert.pem
+ssl_key_path: {{ tarzan_conf }}/tarzan/tarzan_key.pem
 
 ######
 ## Specify how Kong performs DNS resolution (in the `dns_resolvers_available` property) you want to use.

--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -56,8 +56,8 @@ cluster_listen_rpc: "127.0.0.1:7373"
 
 ######
 ## The path to the SSL certificate and key that Kong will use when listening on the `https` port.
-ssl_cert_path: {{ tarzan_conf }}/tarzan/tarzan_cert.pem
-ssl_key_path: {{ tarzan_conf }}/tarzan/tarzan_key.pem
+ssl_cert_path: {{ tarzan_conf }}/tarzan_cert.pem
+ssl_key_path: {{ tarzan_conf }}/tarzan_key.pem
 
 ######
 ## Specify how Kong performs DNS resolution (in the `dns_resolvers_available` property) you want to use.


### PR DESCRIPTION
Today we're using an auto-generated self signed SSL cert located at `/proj/ngi2016001/private/ngi_pipeline/log/tarzan/ssl`. This causes clients to warn about it being self signed. To circumvent this one can add the contents of the cert in the client's CA bundle (e.g. in the one included in Python's `request` library, which is used by Stackstorm). 

But apparently these auto-generated certs are only valid for 1 month, so the client is still complaining as the current cert has expired. 

Therefore we're now instead manually generating a self-signed cert that we put in the Tarzan conf dir. 