### PR TITLE
Fix template syntax error

### DIFF
--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -56,8 +56,8 @@ cluster_listen_rpc: "127.0.0.1:7373"
 
 ######
 ## The path to the SSL certificate and key that Kong will use when listening on the `https` port.
-ssl_cert_path: {{ tarzan_conf }}/tarzan_cert.pem
-ssl_key_path: {{ tarzan_conf }}/tarzan_key.pem
+ssl_cert_path: [% tarzan_conf %]/tarzan_cert.pem
+ssl_key_path: [% tarzan_conf %]/tarzan_key.pem
 
 ######
 ## Specify how Kong performs DNS resolution (in the `dns_resolvers_available` property) you want to use.


### PR DESCRIPTION
Kong's template uses an other Jinja pattern `[% %]` due to the embedded nginx conf parses `{{ }}` as well. 