### PR TITLE
Resolved ngi-rnaseq syntax error

### DIFF
--- a/roles/ngi-rnaseq/tasks/main.yml
+++ b/roles/ngi-rnaseq/tasks/main.yml
@@ -20,8 +20,8 @@
               line="export {{ item }}={{ nextflow_dest }}"
               backup=no
   with_items:
-  - { "NXF_HOME" }
-  - { "NXF_LAUNCHER" }
+  - "NXF_HOME"
+  - "NXF_LAUNCHER" 
 
 - name: Fetch NGI-RNAseq from GitHub
   git: repo="{{ ngi_rnaseq_repo }}"


### PR DESCRIPTION
Turns out when you do not name the items you are supposed to omit the curly brackets.
Honestly did not expect that at all.