### PR TITLE
Fixed multiqc problems from latest deployment

### DIFF
--- a/roles/multiqc/defaults/main.yml
+++ b/roles/multiqc/defaults/main.yml
@@ -4,4 +4,4 @@ multiqc_version: "v0.7"
 
 multiqc_ngi_repo: https://github.com/ewels/MultiQC_NGI.git
 multiqc_ngi_dest: "{{ root_path }}/sw/multiqc_ngi"
-multiqc_ngi_version: "v0.2.1"
+multiqc_ngi_version: "v0.2.2"

--- a/roles/multiqc/tasks/main.yml
+++ b/roles/multiqc/tasks/main.yml
@@ -31,8 +31,8 @@
 - name: Deploy multiqc configs
   template: src="multiqc_config.yml.j2" dest="{{ ngi_pipeline_conf }}/multiqc_{{ item.site }}_config.yml"
   with_items: 
-  - { site: "sthlm", ngi_hooks: "True"}
-  - { site: "upps", ngi_hooks: "False"}
+  - { site: "sthlm", disable_ngi_hooks: "False"}
+  - { site: "upps", disable_ngi_hooks: "True"}
 
 - name: Force multiqc to autorun config
   lineinfile: dest="{{ ngi_pipeline_conf }}/{{ item.script }}"

--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -1,5 +1,5 @@
 ---
 no_version_check: True
 template: 'ngi'
-disable_ngi: {{ item.ngi_hooks }}
+disable_ngi: {{ item.disable_ngi_hooks }}
 push_statusdb: True


### PR DESCRIPTION
The template used the variable `ngi_hooks` for the parameter `disable_ngi_hooks`which caused a logic error to sneak in. Changed the setting as well as the variable name to prevent this in the future.

Also had to update MultiQC_NGI to handle an uncatched exception.