### PR TITLE
Added ngi template as default for stockholm

### DIFF
--- a/roles/multiqc/tasks/main.yml
+++ b/roles/multiqc/tasks/main.yml
@@ -40,4 +40,4 @@
               backup=no
   with_items:
   - { site: "sthlm", script: "{{ bash_env_sthlm_script }}", flags: "-t ngi"}
-  - { site: "upps", script: "{{ bash_env_upps_script }}", flags = "" }
+  - { site: "upps", script: "{{ bash_env_upps_script }}", flags: "" }

--- a/roles/multiqc/tasks/main.yml
+++ b/roles/multiqc/tasks/main.yml
@@ -36,8 +36,8 @@
 
 - name: Force multiqc to autorun config
   lineinfile: dest="{{ ngi_pipeline_conf }}/{{ item.script }}"
-              line="alias multiqc='multiqc -c {{ ngi_pipeline_conf }}/multiqc_{{ item.site }}_config.yml'"
+              line="alias multiqc='multiqc -c {{ ngi_pipeline_conf }}/multiqc_{{ item.site }}_config.yml {{ item.flags }}'"
               backup=no
   with_items:
-  - { site: "sthlm", script: "{{ bash_env_sthlm_script }}" }
-  - { site: "upps", script: "{{ bash_env_upps_script }}" }
+  - { site: "sthlm", script: "{{ bash_env_sthlm_script }}", flags: "-t ngi"}
+  - { site: "upps", script: "{{ bash_env_upps_script }}", flags = "" }


### PR DESCRIPTION
NGI template was confirmed to always be used in Stockholm. 
Implementation isn't the nicest, but the alternative uses a lot of extra lines.