### PR TITLE
NouGAT & NGI_Reports version bump

### DIFF
--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ngi_reports_repo: https://github.com/NationalGenomicsInfrastructure/ngi_reports.git
 ngi_reports_dest: "{{ root_path }}/sw/ngi_reports"
-ngi_reports_version: 6fff57a9854d68f49a427ba7ce2a2f7356bea6e6
+ngi_reports_version: "6ae789d892c9bf82ae86bf4ef1fd287605bced9b"
 ngi_reports_log: "/log/ngi_reports.log"
 ngi_reports_log_sthlm: "{{ ngi_pipeline_sthlm_path }}/{{ ngi_reports_log }}"
 ngi_reports_log_upps: "{{ ngi_pipeline_upps_path }}/{{ ngi_reports_log }}"

--- a/roles/nougat/defaults/main.yml
+++ b/roles/nougat/defaults/main.yml
@@ -8,4 +8,4 @@ frc_align_version: "5b3f53e01cb539c857fd4230ec9410d76220fe22"
 
 nougat_repo: "https://github.com/SciLifeLab/NouGAT.git"
 nougat_dest: "{{ root_path }}/sw/NouGAT"
-nougat_version: "402dd9cbdc301a24599be97ee3267a0429d4bc24"
+nougat_version: "d190015f4aa96b2a217f9ea27b78509df5ad4f1f"


### PR DESCRIPTION
NouGAT previously had a problem with HiseqX's directory structure.
NGI_Reports now handles HDD deliveries.
Some refactoring of the code for both repos.