### PR TITLE
Disable retry files that clutter working area

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 #remote_tmp=/tmp/
 log_path=/lupus/ngi/irma3/log/ansible.log
+retry_files_enabled=false


### PR DESCRIPTION
This will disable the retry files that are usually created with the same prefix as the playbook. It will clean up the working area a little bit as we're not using this feature at the moment. 