### PR TITLE
Use Piper from module system 

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -46,20 +46,15 @@ ngi_pipeline_log_upps: "{{ ngi_pipeline_upps_path }}/log/ngi_pipeline.log"
 ngi_pipeline_db_upps: "{{ ngi_pipeline_upps_path }}/db/records_db_upps.sql"
 ngi_pipeline_db_sthlm: "{{ ngi_pipeline_sthlm_path }}/db/records_db_sthlm.sql"
 
-piper_version: 1.4.0
-piper_src_file: /lupus/ngi/irma3/piper_src/piper-1.4.0.zip
-setupfilecreator_src_file: /lupus/ngi/irma3/piper_src/setupfilecreator-1.4.0.zip
-setupfilecreator_dest: "{{ root_path }}/sw/setupfilecreator"
-ngi_piper_bin_dest: "{{ root_path }}/sw/piper/"
+piper_module_version: 1.5.0
+gatk_bundle_b37: "/sw/data/uppnex/piper_references/2016-04-07/gatk_bundle/2.8/b37/"
 
 ngi_rnaseq_dest: "{{ root_path }}/sw/ngi-rnaseq"
-
-gatk_bundle_b37_origin: "/sw/data/uppnex/reference/biodata/GATK/ftp.broadinstitute.org/bundle/2.8/b37/"
-gatk_bundle_b37: "{{ ngi_resources }}/piper/gatk_bundle/2.8/b37"
-# hg19 is not used, but still referenced in some config
-gatk_bundle_hg19: "{{ ngi_resources }}/piper/gatk_bundle/2.8/hg19"
 
 gatk_key: pontus.larsson_medsci.uu.se.key
 statusdb_creds: statusdb_creds.yml
 
 recipient_mail: ngi_pipeline_operators@scilifelab.se
+
+# Empty placeholder that gets filled by tasks/pre-install.yml
+root_path: 

--- a/install.yml
+++ b/install.yml
@@ -27,7 +27,6 @@
 
   roles: 
     - { role: ngi_pipeline, tags: ngi_pipeline }
-    - { role: piper, tags: piper }
     - { role: func_accounts, tags: func_accounts }
     - { role: tarzan, tags: tarzan }
     - { role: taca, tags: taca }

--- a/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
+++ b/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
@@ -18,12 +18,11 @@ environment:
 #    extra_params:
 #        "--qos": "seqver"
 piper:
-    # Also can be set as an environmental variable $PIPER_QSCRIPTS_DIR
-    path_to_piper_qscripts: {{ ngi_piper_bin_dest }}/piper-{{ piper_version }}/qscripts
     #sample:
     #    required_autosomal_coverage: 28.4
     load_modules:
-        - java/sun_jdk1.7.0_25
+        - bioinfo-tools
+        - "piper/{{ piper_module_version }}"
         - R/3.2.3
     threads: 16
     job_walltime:
@@ -34,7 +33,8 @@ piper:
     #    - arg1
     #    - arg2
     #    - arg3
-    path_to_setupfilecreator: "{{ setupfilecreator_dest }}/setupfilecreator-{{ piper_version }}/bin/setupfilecreator"
+    # TODO: Piper module adds setupfilecreator to the path; unsure if this works or if complete path is required.  
+    path_to_setupfilecreator: setupfilecreator
     gatk_key: "{{ ngi_resources }}/piper/{{ gatk_key }}"
 
 supported_genomes:

--- a/sync.py
+++ b/sync.py
@@ -127,14 +127,9 @@ else:
 
 # Step 5. Sync our destignated folders.
 
-# Old rsync command. Keep this for a while... 
-#rsync_cmd = 	"/bin/rsync --delete -avzP --exclude '*.swp,.git/' --log-file={0} {1} {2} {3} {4} {5} {6} {7}@{8}:{9}".format(rsync_log_path, 
-#		src_root_path + "/conf", src_root_path + "/log", src_root_path + "/db", src_root_path + "/ngi_resources", src_root_path + "/piper_resources", 
-#		src_root_path + "/sw", user, host, dest)
-
-excludes = "--exclude=*.swp --exclude=irma3/ --exclude=resources/piper/gatk_bundle/2.8/b37/"
+excludes = "--exclude=*.swp --exclude=irma3/"
 rsync_cmd = "/bin/rsync -avzP --omit-dir-times --delete {0} --log-file={1} {2} {3}@{4}:{5}".format(excludes, rsync_log_path, src_root_path, user, host, dest) 
-# TODO: Do this cleaner 
+# TODO: Do this cleaner? 
 dry_cmd = "/bin/rsync --dry-run -avzP --omit-dir-times --delete {0} {1} {2}@{3}:{4}".format(excludes, src_root_path, user, host, dest) 
 
 # First doing a dry-run to confirm sync. 


### PR DESCRIPTION
This PR asks ngipipeline to use Piper from the module system instead of deploying it ourselves. It also uses the gatk_bundle provided by UPPMAX. 

It has been test deployed under `devel-root` on `irma3` without problems, but no scripts or programs have been tried. There are some values that might need adjustment after more proper testing. 