### PR TITLE
Removed ngi_pipeline from log dir structure

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -37,8 +37,8 @@ ngi_pipeline_upps_delivery: ngi2016001
 ngi_sthlm_softlinks: "{{ proj_root }}/{{ ngi_pipeline_sthlm_delivery }}/nobackup/NGI/softlinks"
 ngi_upps_softlinks: "{{ proj_root }}/{{ ngi_pipeline_upps_delivery }}/nobackup/NGI/softlinks"
 
-ngi_pipeline_sthlm_path: "{{ proj_root }}/{{ ngi_pipeline_sthlm_delivery }}/private/ngi_pipeline/"
-ngi_pipeline_upps_path: "{{ proj_root }}/{{ ngi_pipeline_upps_delivery }}/private/ngi_pipeline/"
+ngi_pipeline_sthlm_path: "{{ proj_root }}/{{ ngi_pipeline_sthlm_delivery }}/private/"
+ngi_pipeline_upps_path: "{{ proj_root }}/{{ ngi_pipeline_upps_delivery }}/private/"
 
 ngi_pipeline_log_sthlm: "{{ ngi_pipeline_sthlm_path }}/log/ngi_pipeline.log"
 ngi_pipeline_log_upps: "{{ ngi_pipeline_upps_path }}/log/ngi_pipeline.log"

--- a/roles/ngi_pipeline/templates/create_ngi_pipeline_dirs.sh.j2
+++ b/roles/ngi_pipeline/templates/create_ngi_pipeline_dirs.sh.j2
@@ -14,8 +14,9 @@ if [ $# -ne 1 ]; then
         exit 1
 fi
 
-mkdir -p {{ proj_root }}/$1/private/ngi_pipeline/log
-mkdir -p {{ proj_root }}/$1/private/ngi_pipeline/db
+
+mkdir -p {{ proj_root }}/$1/private/log
+mkdir -p {{ proj_root }}/$1/private/db
 mkdir -p {{ proj_root }}/$1/nobackup/NGI/softlinks
 mkdir -p {{ proj_root }}/$1/private/log/supervisord
 ln -s {{ ngi_pipeline_dest }}/DELIVERY.README.txt {{ proj_root }}/$1/nobackup/NGI/softlinks/DELIVERY.README.txt

--- a/roles/ngi_pipeline/templates/create_ngi_pipeline_dirs.sh.j2
+++ b/roles/ngi_pipeline/templates/create_ngi_pipeline_dirs.sh.j2
@@ -17,7 +17,7 @@ fi
 mkdir -p {{ proj_root }}/$1/private/ngi_pipeline/log
 mkdir -p {{ proj_root }}/$1/private/ngi_pipeline/db
 mkdir -p {{ proj_root }}/$1/nobackup/NGI/softlinks
-mkdir -p {{ proj_root }}/$1/private/ngi_pipeline/log/supervisord
+mkdir -p {{ proj_root }}/$1/private/log/supervisord
 ln -s {{ ngi_pipeline_dest }}/DELIVERY.README.txt {{ proj_root }}/$1/nobackup/NGI/softlinks/DELIVERY.README.txt
 ln -s {{ ngi_pipeline_dest }}/scripts/applyRecalibration.sh {{ proj_root }}/$1/nobackup/NGI/softlinks/applyRecalibration.sh
 ln -s {{ ngi_pipeline_dest }}/scripts/bam2fastq.sh {{ proj_root }}/$1/nobackup/NGI/softlinks/bam2fastq.sh

--- a/roles/ngi_reports/templates/ngi_reports_sthlm.conf.j2
+++ b/roles/ngi_reports/templates/ngi_reports_sthlm.conf.j2
@@ -33,4 +33,4 @@ dm3 = Drosophila_melanogaster
 >250 : 60
 
 [log]
-log_dir: {{ ngi_pipeline_log_sthlm }}
+log_dir: {{ ngi_pipeline_sthlm_path }}/log/ngi_reports.log

--- a/roles/ngi_reports/templates/ngi_reports_upps.conf.j2
+++ b/roles/ngi_reports/templates/ngi_reports_upps.conf.j2
@@ -23,4 +23,4 @@ xenTro2: Xenopus
 dm3: Drosophila
 
 [log]
-log_dir: {{ ngi_pipeline_log_upps }}
+log_dir: {{ ngi_pipeline_upps_path }}/log/ngi_reports.log


### PR DESCRIPTION
This has been bugging me for a while. 
Since /private/ became a sorts of generalized log folder it was really counterintuitive for it to be a subfolder of ngi_pipeline.