### PR TITLE
Load piper in the shell 

### DIFF
--- a/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
+++ b/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
@@ -22,7 +22,7 @@ piper:
     #    required_autosomal_coverage: 28.4
     load_modules:
         - bioinfo-tools
-        - "piper/{{ piper_module_version }}"
+        - piper/{{ piper_module_version }}
         - R/3.2.3
     threads: 16
     job_walltime:

--- a/roles/ngi_pipeline/templates/sourceme_common.sh.j2
+++ b/roles/ngi_pipeline/templates/sourceme_common.sh.j2
@@ -21,3 +21,5 @@ else
 fi
 
 export PS1="$IRMA_PROMPT $PS1"
+
+module load bioinfo-tools piper/{{ piper_module_version }}


### PR DESCRIPTION
Previously we only tried to load Piper in the ngipipeline, but it seems to have failed. Probably due to the quotes that ended up in the config. This error wasn't found during testing because parts from the old environment was still present that made ngipipeline fall back to those piper settings instead. 

We're also adding the module load to the shell for interactive usage/testing (and it will also function as a backup of the module load in ngipipeline fails, because then the environment from the shell will be used instead). 
