### PR TITLE
Fixes and updates to the staging env 

### DIFF
--- a/roles/arteria-checksum-ws/defaults/main.yml
+++ b/roles/arteria-checksum-ws/defaults/main.yml
@@ -1,23 +1,30 @@
 ---
 
-# _environment can be set to e.g. "staging" on the command line. 
-# _version is then also preferably changed.
+# If deploying to staging one should call with 
+# -e deployment_environment=staging
+# One can also override the default installed version 
+# by overriding the arteria_checksum_version on the command line. 
 #
 # This will set corresponding paths and use the appropriate port.  
 arteria_checksum_repo: https://github.com/arteria-project/arteria-checksum.git
 arteria_checksum_version: v1.0.3
-arteria_checksum_environment: production
 
 # These values will be appended with production and staging specific 
 # paths in the tasks.
 #
-# NB. The log dirs need to be created manually on destination cluster. 
-arteria_checksum_monitored_path: "{{ proj_root }}/{{ ngi_pipeline_upps_delivery }}/incoming"
+# NB. The log dirs need to be created manually on destination cluster.
+#
+# NB 2. Hard coded root path for runfolders, because that path 
+# needs to be reachable from outside world; i.e. have to be under /proj.
+# And hard coded log paths because we do not want the log files 
+# to disappear when the wildwest directory is cleaned out with every 
+# staging sync. 
+arteria_checksum_monitored_path: "/proj/{{ ngi_pipeline_upps_delivery }}/incoming"
 arteria_checksum_env_root: "{{ root_path }}/sw/arteria/checksum_venv/"
 arteria_checksum_src_path: "{{ root_path }}/sw/arteria/checksum_src/"
 arteria_checksum_config_root: "{{ ngi_pipeline_conf }}/arteria/checksum/"
-arteria_checksum_md5sum_log_dir: "{{ ngi_pipeline_upps_path }}/log/arteria/checksum_md5sum/"
-arteria_checksum_service_log: "{{ ngi_pipeline_upps_path }}/log/arteria/checksum-ws/"
+arteria_checksum_md5sum_log_dir: "/proj/{{ ngi_pipeline_upps_delivery }}/private/log/arteria/checksum_md5sum/"
+arteria_checksum_service_log: "/proj/{{ ngi_pipeline_upps_delivery }}/private/log/arteria/checksum-ws/"
 
 
 arteria_checksum_port_prod: 10420

--- a/roles/arteria-checksum-ws/tasks/2_install_config.yml
+++ b/roles/arteria-checksum-ws/tasks/2_install_config.yml
@@ -19,7 +19,7 @@
 - name: modify uppsala's supervisord conf to start arteria-checksum-ws 
   ini_file: 
     dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
-    section="program:arteria-checksum-ws-{{ arteria_checksum_environment }}"
+    section="program:arteria-checksum-ws-{{ deployment_environment }}"
     option=command
     value="{{ arteria_checksum_env_root }}/bin/checksum-ws --configroot={{ arteria_checksum_config_root }} --port={{ arteria_checksum_port }}"
     backup=no
@@ -27,7 +27,7 @@
 - name: modify uppsala's supervisord conf to start arteria-checksum-ws
   ini_file: 
     dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
-    section="program:arteria-checksum-ws-{{ arteria_checksum_environment }}"
+    section="program:arteria-checksum-ws-{{ deployment_environment }}"
     option=autorestart
     value=true
     backup=no

--- a/roles/arteria-checksum-ws/tasks/main.yml
+++ b/roles/arteria-checksum-ws/tasks/main.yml
@@ -5,24 +5,18 @@
 # Production 
 - set_fact: 
     arteria_checksum_monitored_path: "{{ arteria_checksum_monitored_path }}"
-    arteria_checksum_env_root: "{{ arteria_checksum_env_root }}/production/"
-    arteria_checksum_src_path: "{{ arteria_checksum_src_path }}/production/"
-    arteria_checksum_config_root: "{{ arteria_checksum_config_root }}/production/"
     arteria_checksum_md5sum_log_dir: "{{ arteria_checksum_md5sum_log_dir }}/production"
     arteria_checksum_service_log: "{{ arteria_checksum_service_log}}/production"
     arteria_checksum_port: "{{ arteria_checksum_port_prod }}"
-  when: arteria_checksum_environment == "production"
+  when: deployment_environment == "production"
 
 # Staging
 - set_fact:
     arteria_checksum_monitored_path: "{{ arteria_checksum_monitored_path }}/staging/"
-    arteria_checksum_env_root: "{{ arteria_checksum_env_root }}/staging/"
-    arteria_checksum_src_path: "{{ arteria_checksum_src_path }}/staging/"
-    arteria_checksum_config_root: "{{ arteria_checksum_config_root }}/staging/"
     arteria_checksum_md5sum_log_dir: "{{ arteria_checksum_md5sum_log_dir }}/staging"
     arteria_checksum_service_log: "{{ arteria_checksum_service_log}}/staging"
     arteria_checksum_port: "{{ arteria_checksum_port_stage }}"
-  when: arteria_checksum_environment == "staging"
+  when: deployment_environment in [ "staging", "devel" ]
 
 - include: 1_install.yml
 

--- a/roles/arteria-siswrap-ws/defaults/main.yml
+++ b/roles/arteria-siswrap-ws/defaults/main.yml
@@ -1,12 +1,13 @@
 ---
 
-# _environment can be set to e.g. "staging" on the command line. 
-# _version is then also preferably changed.
+# If deploying to staging one should call with 
+# -e deployment_environment=staging
+# One can also override the default installed version 
+# by overriding the arteria_checksum_version on the command line. 
 #
 # This will set corresponding paths and use the appropriate port. 
 arteria_siswrap_repo: https://github.com/arteria-project/arteria-siswrap.git
 arteria_siswrap_version: v1.1.0
-arteria_siswrap_environment: production
 
 arteria_install_path: "{{ root_path }}/sw/arteria"
 
@@ -14,13 +15,19 @@ arteria_install_path: "{{ root_path }}/sw/arteria"
 # paths in the tasks.
 #
 # NB. The log dirs need to be created manually on destination cluster.
+#
+# NB 2. Hard coded root path for runfolders, because that path 
+# needs to be reachable from outside world; i.e. have to be under /proj
+# And hard coded log paths because we do not want the log files 
+# to disappear when the wildwest directory is cleaned out with every 
+# staging sync. 
 arteria_siswrap_env_root: "{{ arteria_install_path }}/siswrap_venv"
 arteria_siswrap_sources_path: "{{ arteria_install_path }}/siswrap_src"
 arteria_siswrap_config_root: "{{ ngi_pipeline_conf }}/arteria/siswrap"
 arteria_siswrap_app_config: "{{ arteria_siswrap_config_root }}/app.config"
 arteria_siswrap_logger_config: "{{ arteria_siswrap_config_root }}/logger.config"
-arteria_siswrap_log: "{{ ngi_pipeline_upps_path }}/log/arteria/siswrap-ws"
-runfolder_path: "{{ proj_root }}/{{ ngi_pipeline_upps_delivery }}/incoming/"
+arteria_siswrap_log: "/proj/{{ ngi_pipeline_upps_delivery }}/private/log/arteria/siswrap-ws"
+runfolder_path: "/proj/{{ ngi_pipeline_upps_delivery }}/incoming/"
 
 arteria_siswrap_port_prod: 10430
 arteria_siswrap_port_stage: 10431
@@ -29,7 +36,7 @@ arteria_siswrap_mail_to: arteria-project@googlegroups.com
 
 virtual_env_command: "/usr/bin/python /lupus/ngi/irma3/virtualenv-15.0.0/virtualenv.py"
 
-sisyphus_path: "{{ arteria_siswrap_env_root }}/deps/sisyphus/" # set by a task
+sisyphus_path: "{{ arteria_siswrap_env_root }}/deps/sisyphus/"
 sisyphus_git_repo: https://github.com/Molmed/sisyphus.git
 sisyphus_repo_branch: master
 

--- a/roles/arteria-siswrap-ws/tasks/main.yml
+++ b/roles/arteria-siswrap-ws/tasks/main.yml
@@ -2,25 +2,17 @@
 
 # Production values
 - set_fact: 
-    arteria_siswrap_env_root: "{{ arteria_siswrap_env_root }}/production/"
-    arteria_siswrap_sources_path: "{{ arteria_siswrap_sources_path }}/production/"
-    arteria_siswrap_config_root: "{{ arteria_siswrap_config_root }}/production/"
     arteria_siswrap_log: "{{ arteria_siswrap_log }}/production"
     runfolder_path: "{{ runfolder_path }}"
     arteria_siswrap_port: "{{ arteria_siswrap_port_prod }}"
-    sisyphus_path: "{{ arteria_siswrap_env_root }}/deps/sisyphus/"
-  when: arteria_siswrap_environment == "production"
+  when: deployment_environment == "production"
 
 # Staging values
 - set_fact: 
-    arteria_siswrap_env_root: "{{ arteria_siswrap_env_root }}/staging/"
-    arteria_siswrap_sources_path: "{{ arteria_siswrap_sources_path }}/staging/"
-    arteria_siswrap_config_root: "{{ arteria_siswrap_config_root }}/staging/"
     arteria_siswrap_log: "{{ arteria_siswrap_log }}/staging"
     runfolder_path: "{{ runfolder_path }}/staging/"
     arteria_siswrap_port: "{{ arteria_siswrap_port_stage }}"
-    sisyphus_path: "{{ arteria_siswrap_env_root }}/deps/sisyphus/"
-  when: arteria_siswrap_environment == "staging"
+  when: deployment_environment in [ "staging", "devel" ]
 
 - include: install.yml
 - include: sisyphus.yml
@@ -45,7 +37,7 @@
 - name: modify uppsala's supervisord conf to start arteria-siswrap-ws 
   ini_file: 
     dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
-    section="program:arteria-siswrap-ws-{{ arteria_siswrap_environment }}"
+    section="program:arteria-siswrap-ws-{{ deployment_environment }}"
     option=command
     value="{{ arteria_siswrap_env_root }}/bin/siswrap-ws --configroot={{ arteria_siswrap_config_root }} --port={{ arteria_siswrap_port }}"
     backup=no
@@ -53,7 +45,7 @@
 - name: modify uppsala's supervisord conf to autostart arteria-siswrap-ws
   ini_file: 
     dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
-    section="program:arteria-siswrap-ws-{{ arteria_siswrap_environment }}"
+    section="program:arteria-siswrap-ws-{{ deployment_environment }}"
     option=autorestart
     value=true
     backup=no

--- a/roles/ngi_pipeline/templates/sourceme_common.sh.j2
+++ b/roles/ngi_pipeline/templates/sourceme_common.sh.j2
@@ -20,6 +20,6 @@ else
 	IRMA_PROMPT="Stage/$IRMA_VER"
 fi
 
-export PS1="$IRMA_PROMPT $PS1"
+export PS1="$IRMA_PROMPT [\u@\h \w]$ "
 
 module load bioinfo-tools piper/{{ piper_module_version }}

--- a/tasks/pre-install.yml
+++ b/tasks/pre-install.yml
@@ -65,8 +65,8 @@
 
   - block: 
     - name: set proj root for production
-       set_fact: 
-         proj_root: "/proj/"
+      set_fact: 
+        proj_root: "/proj/"
     - name: set delivery root for production
       set_fact: 
         milou_delivery_root: "/pica/sw/links/proj/"

--- a/tasks/pre-install.yml
+++ b/tasks/pre-install.yml
@@ -63,20 +63,19 @@
         - "{{ milou_delivery_root }}"
     when: deployment_environment == "staging"
 
-  - name: set proj root for production
-    set_fact: 
-      proj_root: "/proj/"
-  - name: set delivery root for production
-    set_fact: 
-      milou_delivery_root: "/pica/sw/links/proj/"
-    when: deployment_environment == "production"
-  
-  # charon variables are fetched from private host_vars/127.0.0.1/charon_credentials.yml 
-  - name: set charon envs for production 
-    set_fact:   
-      charon_base_url: "{{ charon_base_url_prod }}"
-      charon_api_token_sthlm: "{{ charon_api_token_sthlm_prod }}"
-      charon_api_token_upps: "{{ charon_api_token_upps_prod }}"
+  - block: 
+    - name: set proj root for production
+       set_fact: 
+         proj_root: "/proj/"
+    - name: set delivery root for production
+      set_fact: 
+        milou_delivery_root: "/pica/sw/links/proj/"
+    # charon variables are fetched from private host_vars/127.0.0.1/charon_credentials.yml 
+    - name: set charon envs for production 
+      set_fact:   
+        charon_base_url: "{{ charon_base_url_prod }}"
+        charon_api_token_sthlm: "{{ charon_api_token_sthlm_prod }}"
+        charon_api_token_upps: "{{ charon_api_token_upps_prod }}"
     when: deployment_environment == "production"
 
   - name: set charon envs for staging and devel


### PR DESCRIPTION
This PR mainly updates the Arteria roles so that they use the Irma staging/prod environments instead of having their own internal staging/prod combos. 

It also fixes a bug with `tasks/pre-install.yml` where `proj_root` got set to `/proj` even in staging due to a mistake I made when I added the `set_fact` for `milou_delivery`. I assumed the tasks were in a `block` only evaluated for production setups, but instead it got set all the time. 

Then we're now setting the Bash path explicitly instead of re-using the `PS1` variable, because that didn't work when having a staging env as a personal user (although it did work as a func user in production mode). Having it set like this instead makes it work in both setups though. 