### PR TITLE
Fix to add piper module to sbatch

### DIFF
--- a/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
+++ b/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
@@ -21,8 +21,7 @@ piper:
     #sample:
     #    required_autosomal_coverage: 28.4
     load_modules:
-        - bioinfo-tools
-        - piper/{{ piper_module_version }}
+        - bioinfo-tools piper/{{ piper_module_version }}
         - R/3.2.3
     threads: 16
     job_walltime:


### PR DESCRIPTION
This is verified on milou to properly add piper to the sbatch instead of it relying on it being loaded by the user. Props to Denis.