### PR TITLE
Added a few dirs to be created

### DIFF
--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -29,15 +29,15 @@
 - name: Install ngi_pipeline
   shell: "cd {{ ngi_pipeline_dest }} && {{ ngi_pipeline_venv }}/bin/pip install ."
  
-- name: Create ngi pipeline conf directory 
+- name: Create ngi_pipeline conf directory 
   file: path="{{ ngi_pipeline_conf }}" state=directory mode=g+s
 
-- name: Create ngi pipeline incoming directories
+- name: Create ngi_pipeline staging incoming directories
   file: path="{{ proj_root }}/{{ item.site }}/incoming" state=directory mode=g+s
   with_items:
   - { site: {{ "ngi_pipeline_sthlm_delivery }}" }
   - { site: {{ "ngi_pipeline_upps_delivery }}" }
-
+  when: deployment_environment == "staging"
 
 - name: Install PyVCF for joint calling 
   shell: "{{ ngi_pipeline_venv }}/bin/pip install PyVCF"

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -32,6 +32,13 @@
 - name: Create ngi pipeline conf directory 
   file: path="{{ ngi_pipeline_conf }}" state=directory mode=g+s
 
+- name: Create ngi pipeline incoming directories
+  file: path="{{ proj_root }}/{{ item.site }}/incoming" state=directory mode=g+s
+  with_items:
+  - { site: {{ "ngi_pipeline_sthlm_delivery }}" }
+  - { site: {{ "ngi_pipeline_upps_delivery }}" }
+
+
 - name: Install PyVCF for joint calling 
   shell: "{{ ngi_pipeline_venv }}/bin/pip install PyVCF"
 

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -35,8 +35,8 @@
 - name: Create ngi_pipeline staging incoming directories
   file: path="{{ proj_root }}/{{ item.site }}/incoming" state=directory mode=g+s
   with_items:
-  - { site: {{ "ngi_pipeline_sthlm_delivery }}" }
-  - { site: {{ "ngi_pipeline_upps_delivery }}" }
+  - { site: "{{ ngi_pipeline_sthlm_delivery }}" }
+  - { site: "{{ ngi_pipeline_upps_delivery }}" }
   when: deployment_environment == "staging"
 
 - name: Install PyVCF for joint calling 

--- a/roles/ngi_pipeline/templates/create_ngi_pipeline_dirs.sh.j2
+++ b/roles/ngi_pipeline/templates/create_ngi_pipeline_dirs.sh.j2
@@ -18,6 +18,7 @@ fi
 mkdir -p {{ proj_root }}/$1/private/log
 mkdir -p {{ proj_root }}/$1/private/db
 mkdir -p {{ proj_root }}/$1/nobackup/NGI/softlinks
+mkdir -p {{ proj_root }}/$1/nobackup/NGI/denovo
 mkdir -p {{ proj_root }}/$1/private/log/supervisord
 ln -s /lupus/ngi/production/latest/sw/ngi_pipeline/DELIVERY.README.txt {{ proj_root }}/$1/nobackup/NGI/softlinks/DELIVERY.README.txt
 ln -s /lupus/ngi/production/latest/sw/ngi_pipeline/scripts/applyRecalibration.sh {{ proj_root }}/$1/nobackup/NGI/softlinks/applyRecalibration.sh


### PR DESCRIPTION
If ngi_pipeline is ran with a relative flowcell path it checks out the `incoming` directory. As such we should ensure that there always exists one.
Having the recipe create a `denovo` directory for denovo QC rather than relying on a nice user creating one is also a good idea.