### PR TITLE
Multiqc upgrade

### DIFF
--- a/roles/multiqc/defaults/main.yml
+++ b/roles/multiqc/defaults/main.yml
@@ -1,7 +1,7 @@
 multiqc_repo: https://github.com/ewels/MultiQC.git
 multiqc_dest: "{{ root_path }}/sw/multiqc"
-multiqc_version: "v0.7"
+multiqc_version: "v0.8"
 
 multiqc_ngi_repo: https://github.com/ewels/MultiQC_NGI.git
 multiqc_ngi_dest: "{{ root_path }}/sw/multiqc_ngi"
-multiqc_ngi_version: "v0.2.2"
+multiqc_ngi_version: "v0.3"

--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -2,7 +2,22 @@
 no_version_check: True
 template: 'ngi'
 disable_ngi: {{ item.disable_ngi_hooks }}
-push_statusdb: True
+
 extra_fn_clean_exts:
     - .bowtie_log
     - .featureCounts
+
+fn_ignore_paths:
+    - '*/piper_ngi/01_raw_alignments/*'
+    - '*/piper_ngi/02_preliminary_alignment_qc/*'
+    - '*/piper_ngi/03_genotype_concordance/*'
+    - '*/piper_ngi/04_merged_alignments/*'
+
+#True for production, False for Staging
+{% if {{ deployment_environment }} == "production" %}
+push_statusdb: True
+save_remote: True
+remote_sshkey: '~/.ssh/id_rsa'  # Optional
+remote_port: '5912'             # Optional
+remote_destination: 'genomics.www@tools.scilifelab.se:/var/local/mqc_reports/'
+{% endif %}

--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -14,7 +14,7 @@ fn_ignore_paths:
     - '*/piper_ngi/04_merged_alignments/*'
 
 #True for production, False for Staging
-{% if {{ deployment_environment }} == "production" %}
+{% if "{{ deployment_environment }}" == "production" %}
 push_statusdb: True
 save_remote: True
 remote_sshkey: '~/.ssh/id_rsa'  # Optional


### PR DESCRIPTION
This commit updates multiqc to version 0.8 and the multiqc_ngi plugin to version 0.3, both which are largely considered stable. The configuration has also been updated as to store multiqc reports on one of our servers.
