### PR TITLE
Create staging links to validation data

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -49,5 +49,10 @@ statusdb_creds: statusdb_creds.yml
 
 recipient_mail: ngi_pipeline_operators@scilifelab.se
 
+validation_data_root: "/lupus/ngi/validation_data/"
+validation_data: 
+ - "160915_ST-1234_0123_ATESTFCCXX"
+ - "160915_ST-1234_0124_BCHR22CCXX"
+
 # Empty placeholder that gets filled by tasks/pre-install.yml
 root_path: 

--- a/tasks/pre-install.yml
+++ b/tasks/pre-install.yml
@@ -56,11 +56,24 @@
     - name: set delivery root for staging 
       set_fact: 
         milou_delivery_root: "{{ proj_root }}/milou-delivery/"
-    - name: create staging proj root dir (wildwest) and milou-delivery
+    - name: set path to staging incoming dir 
+      set_fact: 
+        incoming_dir_upps: "{{ proj_root }}/{{ ngi_pipeline_upps_delivery }}/incoming/"
+        incoming_dir_sthlm: "{{ proj_root }}/{{ ngi_pipeline_sthlm_delivery }}/incoming/"
+    - name: create staging proj root dir (wildwest), milou-delivery and incoming dirs 
       file: path={{ item }} state=directory mode="g+rwxs,u+rwx"
       with_items: 
         - "{{ proj_root }}"
         - "{{ milou_delivery_root }}"
+        - "{{ incoming_dir_upps }}"
+        - "{{ incoming_dir_sthlm }}"
+    - name: create wildwest symlinks to validation data
+      file: src={{ validation_data_root }}/{{ item.src }} dest={{ item.dest }} state=link force=yes
+      with_items: 
+        - { dest: "{{ incoming_dir_upps }}/{{ validation_data[0] }}", src: "{{ validation_data[0] }}" }
+        - { dest: "{{ incoming_dir_upps }}/{{ validation_data[1] }}", src: "{{ validation_data[1] }}" }
+        - { dest: "{{ incoming_dir_sthlm }}/{{ validation_data[0] }}", src: "{{ validation_data[0] }}" }
+        - { dest: "{{ incoming_dir_sthlm }}/{{ validation_data[1] }}", src: "{{ validation_data[1] }}" }
     when: deployment_environment == "staging"
 
   - block: 


### PR DESCRIPTION
`/lupus/ngi/validation_data/` is manually populated with validation data on Irma, but not on irma3. Because `/lupus/ngi/staging/wildwest` is cleaned with every staging sync it is not enough to have static symlinks setup, but we need to re-create them for every deployment. 

A potential problem with this might come up in the future when rsyncing (with the `--delete` flag) as an other user, and if some of these symlinks are supposed to be removed/renamed. Then the rsync might fail with this, as file permissions and symlinks are a different kind of beast. In that case the symlinks will have to be removed manually by the file owner. 