### PR TITLE
NGI Pipeline and TACA version bumps

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -18,7 +18,7 @@ bash_env_sthlm_script: sourceme_sthlm.sh
 
 ngi_pipeline_repo: https://github.com/sylvinite/ngi_pipeline.git
 ngi_pipeline_dest: "{{ root_path }}/sw/ngi_pipeline"
-ngi_pipeline_version: 214651217a1d499d17785a9db4b0346d3c879e2f
+ngi_pipeline_version: 5fe62f93002219d0c8c824d1228b5df1fb7162b9
 NGI_venv_name: "NGI"
 ngi_pipeline_venv: "{{ root_path }}/sw/anaconda/envs/{{ NGI_venv_name }}"
 

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -32,11 +32,11 @@
 - name: Create ngi_pipeline conf directory 
   file: path="{{ ngi_pipeline_conf }}" state=directory mode=g+s
 
-- name: Create ngi_pipeline staging incoming directories
-  file: path="{{ proj_root }}/{{ item.site }}/incoming" state=directory mode=g+s
+- name: Create ngi_pipeline staging incoming & archive directories
+  file: path="{{ proj_root }}/{{ item.site }}/{{ item.dir }}" state=directory mode=g+s
   with_items:
-  - { site: "{{ ngi_pipeline_sthlm_delivery }}" }
-  - { site: "{{ ngi_pipeline_upps_delivery }}" }
+  - { site: "{{ ngi_pipeline_sthlm_delivery }}", dir: [ "incoming", "archive" ]}
+  - { site: "{{ ngi_pipeline_upps_delivery }}", dir: [ "archive", "archive" ]}
   when: deployment_environment == "staging"
 
 - name: Install PyVCF for joint calling 

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -35,9 +35,11 @@
 - name: Create ngi_pipeline staging incoming & archive directories
   file: path="{{ proj_root }}/{{ item.site }}/{{ item.dir }}" state=directory mode=g+s
   with_items:
-  - { site: "{{ ngi_pipeline_sthlm_delivery }}", dir: [ "incoming", "archive" ]}
-  - { site: "{{ ngi_pipeline_upps_delivery }}", dir: [ "archive", "archive" ]}
-  when: deployment_environment == "staging"
+  - { site: "{{ ngi_pipeline_sthlm_delivery }}", dir: "incoming"}
+  - { site: "{{ ngi_pipeline_upps_delivery }}", dir: "incoming"}
+  - { site: "{{ ngi_pipeline_sthlm_delivery }}", dir: "archive"}
+  - { site: "{{ ngi_pipeline_upps_delivery }}", dir: "archive"}
+  when: deployment_environment in ["staging", "devel"]
 
 - name: Install PyVCF for joint calling 
   shell: "{{ ngi_pipeline_venv }}/bin/pip install PyVCF"

--- a/roles/taca/defaults/main.yml
+++ b/roles/taca/defaults/main.yml
@@ -13,4 +13,4 @@ flowcell_parser_version: "587cbfba9179f822a8e85946a13bfcd0b10b5a1b"
 
 taca_repo: "https://github.com/SciLifeLab/TACA.git"
 taca_dest: "{{ root_path }}/sw/TACA"
-taca_version: 88a832cca36b2044941e1e7ce02cee9bc0044835
+taca_version: e161b83baebe38b37d7ea4262b3da6aed4ea0053


### PR DESCRIPTION
Both of these software were running slightly old versions. Might as well bump these since the tests have to be restarted. The TACA bump is necessary to get the cleanup function running for an unusual situation.