### PR TITLE
Updated taca & taca-ngi, reverted ngi_pipeline to safe version

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -16,9 +16,9 @@ bash_env_script: sourceme_common.sh
 bash_env_upps_script: sourceme_upps.sh
 bash_env_sthlm_script: sourceme_sthlm.sh
 
-ngi_pipeline_repo: https://github.com/sylvinite/ngi_pipeline.git
+ngi_pipeline_repo: https://github.com/NationalGenomicsInfrastructure/ngi_pipeline.git
 ngi_pipeline_dest: "{{ root_path }}/sw/ngi_pipeline"
-ngi_pipeline_version: 5fe62f93002219d0c8c824d1228b5df1fb7162b9
+ngi_pipeline_version: dff223f4c7a32c096206b758146a9bc4d180f126
 NGI_venv_name: "NGI"
 ngi_pipeline_venv: "{{ root_path }}/sw/anaconda/envs/{{ NGI_venv_name }}"
 

--- a/roles/taca/defaults/main.yml
+++ b/roles/taca/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 taca_ngi_repo: https://github.com/SciLifeLab/taca-ngi-pipeline.git
 taca_ngi_dest: "{{ root_path }}/sw/taca-ngi-pipeline"
-taca_ngi_version: 1b95a6387ee7addec0721fab482ed55ea2549090
+taca_ngi_version: 422e5061c421256f465169a66dd4721f8e3cc710
 
 statusdb_repo: "https://github.com/SciLifeLab/statusdb.git"
 statusdb_dest: "{{ root_path }}/sw/statusdb"
@@ -13,4 +13,4 @@ flowcell_parser_version: "587cbfba9179f822a8e85946a13bfcd0b10b5a1b"
 
 taca_repo: "https://github.com/SciLifeLab/TACA.git"
 taca_dest: "{{ root_path }}/sw/TACA"
-taca_version: 15ef2d3d84947b6d760335e1179ea7628c6855df
+taca_version: 15a39cff02511016a41c63ef030eec037f056a8d


### PR DESCRIPTION
Interest in deploying other stuff before ngi_pipeline (again).
Reverted ngi_pipeline to official version.
Updated taca-ngi & TACA to allow specific cluster delivery.