### PR TITLE
Mail for Uppsala projects should go to an other address

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -46,7 +46,8 @@ ngi_rnaseq_dest: "{{ root_path }}/sw/ngi-rnaseq"
 
 gatk_key: pontus.larsson_medsci.uu.se.key
 
-recipient_mail: ngi_pipeline_operators@scilifelab.se
+recipient_mail_sthlm: ngi_pipeline_operators@scilifelab.se
+recipient_mail_upps: medsci-molmed-bioinfo@googlegroups.com 
 
 validation_data_root: "/lupus/ngi/validation_data/"
 validation_data: 

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -58,6 +58,7 @@
     ngi_pipeline_db: "{{ ngi_pipeline_db_upps }}"
     ngi_pipeline_slurm_project: "{{ ngi_pipeline_upps_delivery }}"
     ngi_pipeline_log: "{{ ngi_pipeline_log_upps }}"
+    recipient_mail: "{{ recipient_mail_upps }}"
 
 - name: Deploy irma ngi_pipeline config for uppsala 
   template: src="irma_ngi_config.yaml.j2" dest="{{ ngi_pipeline_conf }}/{{ upps_config }}"
@@ -67,6 +68,7 @@
     ngi_pipeline_db: "{{ ngi_pipeline_db_sthlm }}"
     ngi_pipeline_slurm_project: "{{ ngi_pipeline_sthlm_delivery }}"
     ngi_pipeline_log: "{{ ngi_pipeline_log_sthlm }}"
+    recipient_mail: "{{ recipient_mail_sthlm }}"
 
 - name: Deploy irma ngi_pipeline config for stockholm
   template: src="irma_ngi_config.yaml.j2" dest="{{ ngi_pipeline_conf }}/{{ sthlm_config }}"

--- a/roles/nougat/templates/NouGAT_config.conf.j2
+++ b/roles/nougat/templates/NouGAT_config.conf.j2
@@ -3,7 +3,7 @@ qc_analysis:
   time: 1-00:00:00
   project: {{ ngi_pipeline_sthlm_delivery }}
   threads: 16
-  email: {{ recipient_mail }}
+  email: {{ recipient_mail_sthlm }}
   env: {{ NGI_venv_name }}
   qos: normal
 qc_report:
@@ -14,7 +14,7 @@ assembly:
   time: 1-00:00:00
   project: {{ ngi_pipeline_sthlm_delivery }}
   threads: 16
-  email: {{ recipient_mail }}
+  email: {{ recipient_mail_sthlm }}
   env: {{ NGI_venv_name }}
   qos: normal
 validation:
@@ -22,6 +22,6 @@ validation:
   time: 1-00:00:00
   project: {{ ngi_pipeline_sthlm_delivery }}
   threads: 16
-  email: {{ recipient_mail }}
+  email: {{ recipient_mail_sthlm }}
   env: {{ NGI_venv_name }}
   qos: normal

--- a/roles/taca/tasks/main.yml
+++ b/roles/taca/tasks/main.yml
@@ -23,6 +23,7 @@
     ngi_pipeline_site_path: "{{ ngi_pipeline_upps_path }}"
     ngi_site_softlinks: "{{ ngi_upps_softlinks }}"
     ngi_pipeline_site_delivery: "{{ ngi_pipeline_upps_delivery }}"
+    recipient_mail: "{{ recipient_mail_upps }}"
 
 - name: Deploy standard uppsala configs
   template: src="site_taca_delivery.yml.j2" dest="{{ ngi_pipeline_conf }}/TACA/{{ site }}_{{ item.name }}_delivery.yml"
@@ -36,6 +37,7 @@
     ngi_pipeline_site_path: "{{ ngi_pipeline_sthlm_path }}"
     ngi_site_softlinks: "{{ ngi_sthlm_softlinks }}"
     ngi_pipeline_site_delivery: "{{ ngi_pipeline_sthlm_delivery }}"
+    recipient_mail: "{{ recipient_mail_sthlm }}"
 
 - name: Deploy sthlm_taca_local.yml config
   template: src="site_taca_local.yml.j2" dest="{{ ngi_pipeline_conf }}/TACA/{{ site }}_taca_local.yml"


### PR DESCRIPTION
This updates the TACA delivery config and NGI pipeline config used by Uppsala to have a Uppsala specific email address. That way it gets easier for our bioinformaticians to differentiate between our projects in the mailbox. 