### PR TITLE
Readded bashrc piper dependency

### DIFF
--- a/roles/ngi_pipeline/templates/sourceme_common.sh.j2
+++ b/roles/ngi_pipeline/templates/sourceme_common.sh.j2
@@ -3,6 +3,10 @@
 
 export CHARON_BASE_URL={{ charon_base_url }}
 
+# Sadly still integral to NGI Pipeline
+# Hopefully possible to remove dependency in a later version
+module load bioinfo-tools piper/{{ piper_module_version }}
+
 # Force English locale as e.g. some downstream scripts depend on the 
 # pipeline outputing data with "." as decimal output instead of Swedish ",". 
 export LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Sadly cannot get rid of this as of yet.
Piper is called prior to the execution of the sbatch job. This can hopefully be fixed in NGI_Pipeline, but it has already been long enough of a wait just to get the current version of NGI_Pipeline out.