### PR TITLE
Bumped ngi_visual repo, pathed standalone_scripts

### DIFF
--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -8,4 +8,4 @@ ngi_reports_log_upps: "{{ ngi_pipeline_upps_path }}/{{ ngi_reports_log }}"
 
 ngi_visual_repo: https://github.com/NationalGenomicsInfrastructure/ngi_visualizations.git 
 ngi_visual_dest: "{{ sw_path }}//ngi_visualization"
-ngi_visual_version: f827f154653185d5cc9439fa61fefee362971d32
+ngi_visual_version: 1bdc2d51d8588ec3067ada873adadb0aa661251d

--- a/roles/standalone_scripts/tasks/main.yml
+++ b/roles/standalone_scripts/tasks/main.yml
@@ -1,7 +1,14 @@
-#Kind of meager recipe, but will most likely grow from dependencies
+# Kind of meager recipe, but will most likely grow from dependencies
 
 - name: Fetch standalone_scripts from GitHub
   git: repo="{{ ss_repo }}"
        dest="{{ ss_dest }}"
        version="{{ ss_version }}"
        force=yes
+
+# Since the standalone repo is more free-form than others
+# putting PATH at end of $PATH as a safeguard from future problems
+- name: Add standalone scripts to end of $PATH via sourceme
+  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
+              line='export PATH=$PATH:{{ ss_dest }}'
+              backup=no

--- a/roles/standalone_scripts/tasks/main.yml
+++ b/roles/standalone_scripts/tasks/main.yml
@@ -9,6 +9,6 @@
 # Since the standalone repo is more free-form than others
 # putting PATH at end of $PATH as a safeguard from future problems
 - name: Add standalone scripts to end of $PATH via sourceme
-  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
+  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_sthlm_script }}
               line='export PATH=$PATH:{{ ss_dest }}'
               backup=no


### PR DESCRIPTION
New NGI_visualizations version is necessary for some of the newest MultiQC features.

Standalone scripts has been requested to be added to path. Since this repo is way more liberal than others, I am adding it the end of PATH to avoid the scripts taking priority in possible future naming conflicts. This will hopefully _never_ happen, but this is at least a minor safeguard for it.