### PR TITLE
make ngi_reports required for Uppsala deliveries

### DIFF
--- a/roles/taca/templates/site_taca_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_delivery.yml.j2
@@ -43,10 +43,16 @@ deliver:
             - <REPORTPATH>/delivery/reports/<PROJECTID>_aggregate_report.csv
             - <STAGINGPATH>/00-Reports
             - no_digest: True
+{% if "upps" == site %}
+            - required: True
+{% endif %}
         -
             - <REPORTPATH>/delivery/reports/<SAMPLEID>_ign_sample_report.html
             - <STAGINGPATH>/<SAMPLEID>/00-Reports
             - no_digest_cache: True
+{% if "upps" == site %}
+            - required: True
+{% endif %}
         - 
             - <ANALYSISPATH>/piper_ngi/07_variant_calls/<SAMPLEID>.*.snpEff.summary.*
             - <STAGINGPATH>/<SAMPLEID>/00-Reports


### PR DESCRIPTION
As the title suggests, deliveries will now fail if ngi_reports fail to be generated, which is the desired behaviour for Uppsala.