### PR TITLE
Don't add ngi_reports' script dir to $PATH 

### DIFF
--- a/roles/ngi_reports/tasks/main.yml
+++ b/roles/ngi_reports/tasks/main.yml
@@ -16,11 +16,6 @@
   args:
     chdir: "{{ ngi_reports_dest }}"
 
-- name: Add ngi_reports scripts to $PATH via sourceme
-  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
-              line='export PATH={{ ngi_reports_dest }}/scripts:$PATH'
-              backup=no
-
 - name: Install pandocfilters submodule
   shell: "{{ ngi_pipeline_venv }}/bin/pip install ."
   args:
@@ -32,7 +27,7 @@
   - { site: "upps" }
   - { site: "sthlm" }
 
-- name: Add ngi_reports to $PATH via sourceme_{{ item.site }}
+- name: Export NGI_REPORTS_CONFIG via sourceme_{{ item.site }}
   lineinfile: dest="{{ ngi_pipeline_conf }}/{{ item.env_script }}"
               line='export NGI_REPORTS_CONFIG={{ ngi_pipeline_conf }}/ngi_reports_{{ item.site }}.conf'
               backup=no


### PR DESCRIPTION
Having the scripts dir in $PATH causes name collision in some situations when resolving the script name `ngi_reports`, as the one we want to call is located in Anaconda's venv dir (that is also in $PATH). 

The files under the scripts dir are helpers that are needed for functionality though, but it should apparently have been solved through other ways already. This needs to be tested though for certainty. 