### PR TITLE
Snapshot Cassandra weekly

### DIFF
--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -58,3 +58,8 @@
               line='1 1 * * 1 {{ cassandra_dest }}/{{ cassandra_version }}/bin/nodetool -h localhost -p 7199 snapshot kong'
               backup=no
 
+- name: dump cassandra schema once a week 
+  lineinfile: dest="{{ ngi_pipeline_conf }}/crontab_upps"
+              line='0 1 * * 1 {{ cassandra_dest }}/{{ cassandra_version }}/bin/cqlsh -e "DESC KEYSPACE kong" > {{ cassandra_db_dest }}/kong_schema-`date +%Y%m%d`.cql'
+              backup=no
+

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -60,6 +60,6 @@
 
 - name: dump cassandra schema once a week 
   lineinfile: dest="{{ ngi_pipeline_conf }}/crontab_upps"
-              line='0 1 * * 1 {{ cassandra_dest }}/{{ cassandra_version }}/bin/cqlsh -e "DESC KEYSPACE kong" > {{ cassandra_db_dest }}/kong_schema-`date +%Y%m%d`.cql'
+              line='0 1 * * 1 export PATH=/usr/bin/:$PATH && {{ cassandra_dest }}/{{ cassandra_version }}/bin/cqlsh -e "DESC KEYSPACE kong" > {{ cassandra_db_dest }}/kong_schema-`date +%Y%m%d`.cql'
               backup=no
 

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -52,3 +52,9 @@
   lineinfile: dest="{{ ngi_pipeline_conf }}/crontab_upps"
               line='38 * * * *      source $HOME/.bash_profile && kong start -c {{ tarzan_conf }}/webproxy.yml'
               backup=no
+
+- name: snapshot cassandra once a week, so that normal backups can be taken of a sany copy of files (kb sizes)  
+  lineinfile: dest="{{ ngi_pipeline_conf }}/crontab_upps"
+              line='1 1 * * 1 {{ cassandra_dest }}/{{ cassandra_version }}/bin/nodetool -h localhost -p 7199 snapshot kong'
+              backup=no
+


### PR DESCRIPTION
This will cause a snapshot to be taken of the Cassandra db (Kong's backend) once a week, so that the normal backup processes that run on `/proj/` dirs can include the files in a well known state. The created snapshots are so minimal (a couple of hundred kb) so no need to do any clean up at the moment. 