### PR TITLE
New ngi-pipeline staging version

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -15,7 +15,7 @@ bash_env_sthlm_script: sourceme_sthlm.sh
 
 ngi_pipeline_repo: https://github.com/NationalGenomicsInfrastructure/ngi_pipeline.git
 ngi_pipeline_dest: "{{ sw_path }}/ngi_pipeline"
-ngi_pipeline_version: 0de2d26086ffbf6686a94060f7ddb9233050a690
+ngi_pipeline_version: 7e22926a8b1dd6ff97636d521ec67ab5288aa968
 NGI_venv_name: "NGI"
 ngi_pipeline_venv: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_name }}"
 


### PR DESCRIPTION
This removes the usage of automatic multiqc start completely, since its usefulness is debatable and it ran into a few issues.