### PR TITLE
Added ngi_reports for sthlm, updated standalone scripts version

### DIFF
--- a/roles/standalone_scripts/defaults/main.yml
+++ b/roles/standalone_scripts/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 ss_repo: "https://github.com/SciLifeLab/standalone_scripts.git"
 ss_dest: "{{ sw_path }}/standalone_scripts"
-ss_version: 3ba06e7ef86cb07932fc142bc63635ab08eba9ad
+ss_version: ac20d199e9724274e62f02219fcb189b87083ba2

--- a/roles/standalone_scripts/defaults/main.yml
+++ b/roles/standalone_scripts/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 ss_repo: "https://github.com/SciLifeLab/standalone_scripts.git"
 ss_dest: "{{ sw_path }}/standalone_scripts"
-ss_version: ac20d199e9724274e62f02219fcb189b87083ba2

--- a/roles/standalone_scripts/tasks/main.yml
+++ b/roles/standalone_scripts/tasks/main.yml
@@ -3,7 +3,6 @@
 - name: Fetch standalone_scripts from GitHub
   git: repo="{{ ss_repo }}"
        dest="{{ ss_dest }}"
-       version="{{ ss_version }}"
        force=yes
 
 # Since the standalone repo is more free-form than others

--- a/roles/taca/templates/site_fastq_delivery.yml.j2
+++ b/roles/taca/templates/site_fastq_delivery.yml.j2
@@ -17,3 +17,8 @@ deliver:
             - <DATAPATH>/<SAMPLEID>/*/*
             - <STAGINGPATH>/<SAMPLEID>/02-FASTQ
             - required: True
+{% if "sthlm" == site %}
+        -
+            - <ANALYSISPATH>/reports/*
+            - <STAGINGPATH>/00-Reports
+{% endif %}

--- a/roles/taca/templates/site_taca_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_delivery.yml.j2
@@ -25,6 +25,11 @@ deliver:
             - <ANALYSISPATH>/qc_sisyphus/reports
             - <STAGINGPATH>/00-Reports/SequenceQC/Sisyphus
 {% endif %}
+{% if "sthlm" == site %}
+        -
+            - <ANALYSISPATH>/reports/*
+            - <STAGINGPATH>/00-Reports
+{% endif %}
 #Adds FASTQ files to Lupus (aka irma) deliveries
 {% if "/proj/" == item.proj_path %}
         -


### PR DESCRIPTION
Recipes now use project name for deliveries.
Standalone scripts version updated to include merge* script.