### PR TITLE
Let UGC deliver data through Mover and SUPR

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -38,6 +38,7 @@
     - { role: ngi-rnaseq, tags: ngi-rnaseq }
     - { role: nougat, tags: nougat }
     - { role: standalone_scripts, tags: standalone_scripts }
+    - { role: ugc, tags: ugc }
 
   environment: "{{ anaconda_env }}"
 

--- a/roles/anaconda/defaults/main.yml
+++ b/roles/anaconda/defaults/main.yml
@@ -1,0 +1,5 @@
+anaconda_file: Anaconda2-4.1.1-Linux-x86_64.sh
+anaconda_checksum: 9413b1d3ca9498ba6f53913df9c43d685dd973440ff10b7fe0c45b1cbdcb582e
+anaconda_url: "http://repo.continuum.io/archive/{{ anaconda_file }}"
+anaconda_src: "/lupus/ngi/irma3/{{ anaconda_file }}"
+

--- a/roles/anaconda/tasks/main.yml
+++ b/roles/anaconda/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Download anaconda
+  get_url: url={{ anaconda_url }} dest={{ anaconda_src }} mode=ug+rwx checksum="sha256:{{ anaconda_checksum }}"
+
+- name: Install anaconda
+  shell: "{{ anaconda_src }} -b -p {{ anaconda_path }}"  
+  args: 
+    creates: "{{ anaconda_path }}/LICENSE.txt"
+

--- a/roles/ngi_pipeline/defaults/main.yml
+++ b/roles/ngi_pipeline/defaults/main.yml
@@ -1,10 +1,4 @@
 --- 
-
-anaconda_file: Anaconda2-4.1.1-Linux-x86_64.sh
-anaconda_checksum: 9413b1d3ca9498ba6f53913df9c43d685dd973440ff10b7fe0c45b1cbdcb582e
-anaconda_url: "http://repo.continuum.io/archive/{{ anaconda_file }}"
-anaconda_src: "/lupus/ngi/irma3/{{ anaconda_file }}"
-
 upps_config: irma_ngi_config_upps.yaml
 sthlm_config: irma_ngi_config_sthlm.yaml
 

--- a/roles/ngi_pipeline/meta/main.yml
+++ b/roles/ngi_pipeline/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: anaconda, tags: anaconda }

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -1,13 +1,5 @@
 ---
 
-- name: Download anaconda
-  get_url: url={{ anaconda_url }} dest={{ anaconda_src }} mode=ug+rwx checksum="sha256:{{ anaconda_checksum }}"
-
-- name: Install anaconda
-  shell: "{{ anaconda_src }} -b -p {{ anaconda_path }}"  
-  args: 
-    creates: "{{ anaconda_path }}/LICENSE.txt"
-
 - name: Fetch ngi_pipeline from github 
   git: repo={{ ngi_pipeline_repo }} 
        dest={{ ngi_pipeline_dest }}

--- a/roles/ugc/defaults/main.yml
+++ b/roles/ugc/defaults/main.yml
@@ -1,0 +1,7 @@
+ugc_delivery_env_path: "{{ sw_path }}/anaconda/envs/ugc_delivery_script/"
+ugc_delivery_env_name: "ugc_delivery_script"
+conda_bin: "{{ sw_path }}/anaconda/bin/conda"
+
+delivery_repo: "http://github.com/molmed/delivery.git"
+delivery_src: "{{ sw_path }}/ugc_delivery_src"
+delivery_version: "master"

--- a/roles/ugc/meta/main.yml
+++ b/roles/ugc/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: anaconda, tags: anaconda }

--- a/roles/ugc/tasks/main.yml
+++ b/roles/ugc/tasks/main.yml
@@ -1,0 +1,27 @@
+- name: create virtual python env for ugc delivery 
+  shell: "{{ conda_bin }} create --name {{ ugc_delivery_env_name }} python=2.7"
+  args: 
+    creates: "{{ ugc_delivery_env_path }}"
+
+- name: get ugc-delivery from git
+  git:
+    repo: "{{ delivery_repo }}"
+    dest: "{{ delivery_src }}" 
+    version: "{{ delivery_version }}"
+
+- name: install ugc delivery requirements
+  pip:
+    virtualenv: "{{ ugc_delivery_env_path }}"
+    requirements: "{{ delivery_src }}/requirements.txt"
+    extra_args: "-U"
+    state: present
+
+- name: install ugc delivery into venv
+  copy: src="{{ delivery_src }}/deliver.py" dest="{{ ugc_delivery_env_path }}/bin/" 
+
+- name: ensure conf dir exists 
+  file: path="{{ ngi_pipeline_conf }}" state=directory
+
+- name: deploy ugc bash env file 
+  template: src="sourceme_ugc.sh.j2" dest="{{ ngi_pipeline_conf }}/sourceme_ugc.sh"
+

--- a/roles/ugc/templates/sourceme_ugc.sh.j2
+++ b/roles/ugc/templates/sourceme_ugc.sh.j2
@@ -1,0 +1,4 @@
+export PATH={{ sw_path }}/anaconda/bin/:$PATH
+
+alias ugc-init="source activate {{ ugc_delivery_env_name }} && cd {{ ugc_delivery_env_path }}"
+alias ugc-dir="cd {{ ugc_delivery_env_path }}"


### PR DESCRIPTION
Initial basic config that UGC can use for delivering runfolders/projects via Mover and SUPR through a helper script (https://github.com/Molmed/delivery). 

As it is setup now they would add a `source /lupus/ngi/production/latest/conf/sourceme_ugc.sh` in their Bash init files, and then whenever they need to do a delivery they can do a `ugc-init` followed by the `python deliver.py .....` command. 

Perhaps UGC needs more features or configs in the future, but this seems sensible as a start. 