### PR TITLE
Make delivery jobs async

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -6,10 +6,22 @@
 # by overriding the arteria_delivery_version on the command line. 
 #
 # This will set corresponding paths and use the appropriate port. 
-arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: master
+#arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
+#arteria_delivery_version: master
+arteria_delivery_repo: https://github.com/johandahlberg/arteria-delivery.git
+arteria_delivery_version: make_jobs_async
 
 arteria_install_path: "{{ sw_path }}/arteria"
+
+
+#ugc_delivery_env_path: "{{ sw_path }}/anaconda/envs/ugc_delivery_script/"
+#ugc_delivery_env_name: "ugc_delivery_script"
+conda_bin: "{{ sw_path }}/anaconda/bin/conda"
+
+#delivery_repo: "http://github.com/molmed/delivery.git"
+#delivery_src: "{{ sw_path }}/ugc_delivery_src"
+#delivery_version: "master"
+
 
 # These values will be appended with production and staging specific
 # paths in the tasks.
@@ -21,7 +33,8 @@ arteria_install_path: "{{ sw_path }}/arteria"
 # And hard coded log paths because we do not want the log files 
 # to disappear when the wildwest directory is cleaned out with every 
 # staging sync. 
-arteria_delivery_env_root: "{{ arteria_install_path }}/delivery_venv"
+#arteria_delivery_env_root: "{{ arteria_install_path }}/delivery_venv"
+arteria_delivery_env_root: "{{ sw_path }}/anaconda/envs/arteria-delivery"
 arteria_delivery_sources_path: "{{ arteria_install_path }}/delivery_src"
 arteria_delivery_config_root: "{{ ngi_pipeline_conf }}/arteria/delivery"
 arteria_delivery_app_config: "{{ arteria_delivery_config_root }}/app.config"

--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -12,16 +12,7 @@ arteria_delivery_repo: https://github.com/johandahlberg/arteria-delivery.git
 arteria_delivery_version: make_jobs_async
 
 arteria_install_path: "{{ sw_path }}/arteria"
-
-
-#ugc_delivery_env_path: "{{ sw_path }}/anaconda/envs/ugc_delivery_script/"
-#ugc_delivery_env_name: "ugc_delivery_script"
 conda_bin: "{{ sw_path }}/anaconda/bin/conda"
-
-#delivery_repo: "http://github.com/molmed/delivery.git"
-#delivery_src: "{{ sw_path }}/ugc_delivery_src"
-#delivery_version: "master"
-
 
 # These values will be appended with production and staging specific
 # paths in the tasks.
@@ -53,4 +44,4 @@ alembic_path: "{{ arteria_delivery_sources_path }}/alembic/"
 arteria_delivery_port_prod: 10440
 arteria_delivery_port_stage: 10441
 
-virtual_env_command: "/usr/bin/python /lupus/ngi/irma3/virtualenv-15.0.0/virtualenv.py"
+#virtual_env_command: "/usr/bin/python /lupus/ngi/irma3/virtualenv-15.0.0/virtualenv.py"

--- a/roles/arteria-delivery-ws/meta/main.yml
+++ b/roles/arteria-delivery-ws/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: anaconda, tags: anaconda }

--- a/roles/arteria-delivery-ws/tasks/install.yml
+++ b/roles/arteria-delivery-ws/tasks/install.yml
@@ -1,4 +1,8 @@
 ---
+- name: create virtual python env for arteria-delivery 
+  shell: "{{ conda_bin }} create --name arteria-delivery python=3.5"
+  args: 
+    creates: "{{ arteria_delivery_env_root }}"
 
 - name: get arteria-delivery from git
   git:
@@ -11,9 +15,9 @@
       requirements: "{{ arteria_delivery_sources_path }}/requirements/dev"
       chdir: "{{ arteria_delivery_sources_path }}"
       virtualenv: "{{ arteria_delivery_env_root }}"
-      virtualenv_command: "{{ virtual_env_command }}"
+#      virtualenv_command: "{{ virtual_env_command }}"
       state: present
-      executable: "{{ arteria_delivery_env_root }}/bin/pip"
+#      executable: "{{ arteria_delivery_env_root }}/bin/pip"
       extra_args: "-U"
 
 - name: install arteria-delivery
@@ -21,8 +25,8 @@
       name: .
       chdir: "{{ arteria_delivery_sources_path }}"
       virtualenv: "{{ arteria_delivery_env_root }}"
-      virtualenv_command: "{{ virtual_env_command }}"
+#      virtualenv_command: "{{ virtual_env_command }}"
       state: present
-      executable: "{{ arteria_delivery_env_root }}/bin/pip"
+#      executable: "{{ arteria_delivery_env_root }}/bin/pip"
       extra_args: "-U"
 

--- a/roles/arteria-delivery-ws/tasks/main.yml
+++ b/roles/arteria-delivery-ws/tasks/main.yml
@@ -44,7 +44,7 @@
     dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
     section="program:arteria-delivery-ws-{{ deployment_environment }}"
     option=command
-    value="{{ arteria_delivery_env_root }}/bin/delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port }}"
+    value="source activate arteria-delivery && delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port }}"
     backup=no
 
 - name: modify uppsala's supervisord conf to autostart arteria-delivery-ws

--- a/roles/arteria-delivery-ws/templates/delivery_logger.config.j2
+++ b/roles/arteria-delivery-ws/templates/delivery_logger.config.j2
@@ -16,7 +16,7 @@ handlers:
 
     file_handler:
         class: logging.handlers.RotatingFileHandler
-        level: WARNING  # By default set to WARNING, but can be changed on runtime
+        level: DEBUG  # By default set to WARNING, but can be changed on runtime
         formatter: simple
         filename: {{ arteria_delivery_log }}
         maxBytes: 10485760  # 10MB


### PR DESCRIPTION
New arteria-delivery that fixes async problems uses Python v3; therefore we need to install it in a conda environment instead. 