### PR TITLE
new entry for TACA local config

### DIFF
--- a/roles/taca/templates/site_taca_local.yml.j2
+++ b/roles/taca/templates/site_taca_local.yml.j2
@@ -8,6 +8,7 @@ cleanup:
                 - "{{ proj_root }}/{{ ngi_pipeline_sthlm_delivery }}/incoming"
                 - "{{ proj_root }}/{{ ngi_pipeline_sthlm_delivery }}/archive"
             relative_project_source: Demultiplexing
+            undet_file_pattern: "Undetermined_*.fastq.gz"
         data_dir: "{{ proj_root }}/{{ ngi_pipeline_sthlm_delivery }}/nobackup/NGI/DATA"
         analysis:
             root: "{{ proj_root }}/{{ ngi_pipeline_sthlm_delivery }}/nobackup/NGI/ANALYSIS"


### PR DESCRIPTION
`taca cleanup` have been updated to remove the Undetermined reads, so the required pattern should be defined in the config file.