### PR TITLE
Further updates to gt_concordance config

### DIFF
--- a/roles/ngi_pipeline/templates/create_ngi_pipeline_dirs.sh.j2
+++ b/roles/ngi_pipeline/templates/create_ngi_pipeline_dirs.sh.j2
@@ -24,6 +24,11 @@ mkdir -p {{ proj_root }}/$1/private/db
 mkdir -p {{ proj_root }}/$1/nobackup/NGI/softlinks
 mkdir -p {{ proj_root }}/$1/nobackup/NGI/DENOVO_BP
 mkdir -p {{ proj_root }}/$1/private/log/supervisord
+#If case since folders are excessive for uppsala
+if [ $1 == "ngi2016003" ]
+mkdir -p {{ proj_root }}/$1/genotype_data/incoming
+mkdir -p {{ proj_root }}/$1/genotype_data/archive
+fi
 ln -s /lupus/ngi/production/latest/sw/ngi_pipeline/DELIVERY.README.txt {{ proj_root }}/$1/nobackup/NGI/softlinks/DELIVERY.README.txt
 ln -s /lupus/ngi/production/latest/sw/ngi_pipeline/scripts/applyRecalibration.sh {{ proj_root }}/$1/nobackup/NGI/softlinks/applyRecalibration.sh
 ln -s /lupus/ngi/production/latest/sw/ngi_pipeline/scripts/bam2fastq.sh {{ proj_root }}/$1/nobackup/NGI/softlinks/bam2fastq.sh

--- a/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
+++ b/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
@@ -85,15 +85,12 @@ qc:
         threads: 1
 
 gt_concordance:
-    #Why not backwards e.g. incoming/Genotype_data ?
     XL_FILES_PATH: {{ proj_root }}/{{ ngi_pipeline_slurm_project }}/genotype_data/incoming
-    XL_FILES_ARCHIVED:  {{ proj_root }}/{{ ngi_pipeline_slurm_project }}/genotype_data/archived
-    #Module load + $GATK_HOME or given path??
+    XL_FILES_ARCHIVED:  {{ proj_root }}/{{ ngi_pipeline_slurm_project }}/genotype_data/archive
     GATK_PATH: /sw/apps/bioinfo/GATK/3.5.0//GenomeAnalysisTK.jar
-    #Why not supported genomes ref?
     GATK_REF_FILE: {{ gatk_bundle_b37 }}/human_g1k_v37.fasta
     GATK_VAR_FILE: {{ gatk_bundle_b37 }}/dbsnp_138.b37.vcf
-    #Going into ngi_pipeline??
+    #Going into ngi_pipeline in the future
     INTERVAL_FILE: {{ proj_root }}/{{ ngi_pipeline_slurm_project }}/genotype_data/static/snps.interval_list
     SNPS_FILE: {{ proj_root }}/{{ ngi_pipeline_slurm_project }}/genotype_data/static/maf_snps.txt
 


### PR DESCRIPTION
Discussed gt_concordance. It is not used by uppsala, but it seems pointless to exclude them from the config. Did however exclude them from the creation of the incoming directories, since it may unlike the config, draw some confusion.

All variabels introduced have been decided to stay, with the exception of the ones pointing to /static/ folders; since the files will be integrated in a later ngi_pipeline push.