### PR TITLE
Removed SNIC_TMP variable set

### DIFF
--- a/roles/ngi-rnaseq/tasks/dependencies.yml
+++ b/roles/ngi-rnaseq/tasks/dependencies.yml
@@ -43,7 +43,6 @@
               line="{{ item.envvar }}"
               backup=no
   with_items:
-  - { envvar: "export SNIC_TMP=/scratch"}
   - { envvar: "export NXF_OPTS='-Xms1g -Xmx4g'"}
   - { envvar: "export NXF_VER={{ nextflow_ver.stdout }}"}
   - { envvar: "export NXF_HOME={{ nextflow_dest }}/workfiles"}


### PR DESCRIPTION
Turns out manually setting SNIC_TMP like this causes some problems when uppsala run piper.
Verified; and since we no longer save workfiles in a write directory - it all works out.