### PR TITLE
taca and ngi_pipeline updates

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -15,7 +15,7 @@ bash_env_sthlm_script: sourceme_sthlm.sh
 
 ngi_pipeline_repo: https://github.com/NationalGenomicsInfrastructure/ngi_pipeline.git
 ngi_pipeline_dest: "{{ sw_path }}/ngi_pipeline"
-ngi_pipeline_version: 19ec5f4651f20eca8d5a94ffd421e0bb436a2fae
+ngi_pipeline_version: 0d18e9f47002cf1ae296d6f9613e05c75c668f45 
 NGI_venv_name: "NGI"
 ngi_pipeline_venv: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_name }}"
 

--- a/roles/taca/defaults/main.yml
+++ b/roles/taca/defaults/main.yml
@@ -13,4 +13,4 @@ flowcell_parser_version: "587cbfba9179f822a8e85946a13bfcd0b10b5a1b"
 
 taca_repo: "https://github.com/SciLifeLab/TACA.git"
 taca_dest: "{{ sw_path }}/TACA"
-taca_version: 43004465f278b2ecbb415cb572b290db8f4def78
+taca_version: 214f7da25c20438795456c51ec81222aa0f13f58 


### PR DESCRIPTION
taca -> regex updated to include inhouse projects while cleanup
ngi_pipeline -> fastq_screen doesn't overwrite result when samples where run on mutliple flowcells