### PR TITLE
NGI-rnaseq release version

### DIFF
--- a/roles/ngi-rnaseq/defaults/main.yml
+++ b/roles/ngi-rnaseq/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 nextflow_dest: "{{ sw_path }}/nextflow"
 ngi_rnaseq_repo: "https://github.com/SciLifeLab/NGI-RNAseq.git"
-ngi_rnaseq_version: ea1f5e7fa8de7e5bbcc8194cb38f790e0e50c9cb
+ngi_rnaseq_version: 8ab47824ade988f2252885bca833b39879a470f4


### PR DESCRIPTION
Could probably switch to versions instead of commit id at this point, but I know the people responsible have a tendency to make hotfixes.