### PR TITLE
NGI_reports custom outdir, taca prints to stdout

### DIFF
--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ngi_reports_repo: https://github.com/NationalGenomicsInfrastructure/ngi_reports.git
 ngi_reports_dest: "{{ sw_path }}/ngi_reports"
-ngi_reports_version: 68734b6fecda39ff4b22acce59d322813a4dad8d
+ngi_reports_version: 9ed66aee87efbafdcde62352e9763fba3232f32e
 ngi_reports_log: "/log/ngi_reports.log"
 ngi_reports_log_sthlm: "{{ ngi_pipeline_sthlm_path }}/{{ ngi_reports_log }}"
 ngi_reports_log_upps: "{{ ngi_pipeline_upps_path }}/{{ ngi_reports_log }}"

--- a/roles/taca/defaults/main.yml
+++ b/roles/taca/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 taca_ngi_repo: https://github.com/SciLifeLab/taca-ngi-pipeline.git
 taca_ngi_dest: "{{ sw_path }}/taca-ngi-pipeline"
-taca_ngi_version: 422e5061c421256f465169a66dd4721f8e3cc710
+taca_ngi_version: 5f2d8b31162cff6bd173d5b8b2f56d87c810ad23
 
 statusdb_repo: "https://github.com/SciLifeLab/statusdb.git"
 statusdb_dest: "{{ sw_path }}/statusdb"
@@ -13,4 +13,4 @@ flowcell_parser_version: "587cbfba9179f822a8e85946a13bfcd0b10b5a1b"
 
 taca_repo: "https://github.com/SciLifeLab/TACA.git"
 taca_dest: "{{ sw_path }}/TACA"
-taca_version: 214f7da25c20438795456c51ec81222aa0f13f58 
+taca_version: 8f5dbf5265e3130a8cc8cf6bf731f8a5c74811fa

--- a/roles/taca/defaults/main.yml
+++ b/roles/taca/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 taca_ngi_repo: https://github.com/SciLifeLab/taca-ngi-pipeline.git
 taca_ngi_dest: "{{ sw_path }}/taca-ngi-pipeline"
-taca_ngi_version: 5f2d8b31162cff6bd173d5b8b2f56d87c810ad23
+taca_ngi_version: 422e5061c421256f465169a66dd4721f8e3cc710
 
 statusdb_repo: "https://github.com/SciLifeLab/statusdb.git"
 statusdb_dest: "{{ sw_path }}/statusdb"


### PR DESCRIPTION
NGI_Reports can now produce reports to project name instead of pid.
TACA now also prints log info to stdout to make errors more apparent.