### PR TITLE
Fix supervisord syntax so that arteria-delivery can start

### DIFF
--- a/roles/arteria-delivery-ws/tasks/main.yml
+++ b/roles/arteria-delivery-ws/tasks/main.yml
@@ -43,7 +43,7 @@
     dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
     section="program:arteria-delivery-ws-{{ deployment_environment }}"
     option=command
-    value="export PATH={{ arteria_delivery_env_root }}/bin:$PATH && source activate arteria-delivery && delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port }}"
+    value="bash -c 'source activate arteria-delivery && exec delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port }}'"
     backup=no
 
 - name: modify uppsala's supervisord conf to autostart arteria-delivery-ws


### PR DESCRIPTION
Apparently `supervisord` doesn't start a new shell when spawning subprocesses, so we need to do a workaround when launching the `arteria-delivery` webservice, as it is using a `conda` environment instead of the previous services that are using normal Python virtualenvs. 