### PR TITLE
Changed sthlm delivery to pname-pid

### DIFF
--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ngi_reports_repo: https://github.com/NationalGenomicsInfrastructure/ngi_reports.git
 ngi_reports_dest: "{{ sw_path }}/ngi_reports"
-ngi_reports_version: 9ed66aee87efbafdcde62352e9763fba3232f32e
+ngi_reports_version: 6c7a7bf98c1354d90f617efbd0c79ae9ce8d6f07
 ngi_reports_log: "/log/ngi_reports.log"
 ngi_reports_log_sthlm: "{{ ngi_pipeline_sthlm_path }}/{{ ngi_reports_log }}"
 ngi_reports_log_upps: "{{ ngi_pipeline_upps_path }}/{{ ngi_reports_log }}"

--- a/roles/taca/templates/site_fastq_delivery.yml.j2
+++ b/roles/taca/templates/site_fastq_delivery.yml.j2
@@ -6,7 +6,11 @@ deliver:
     analysispath: <ROOTPATH>/ANALYSIS/<PROJECTID>
     datapath: <ROOTPATH>/DATA/<PROJECTID>
     stagingpath: <ROOTPATH>/DELIVERY/<PROJECTID>
+{% if "sthlm" == site %}
+    deliverypath: "{{ item.proj_path }}/<UPPNEXID>/INBOX/<PROJECTNAME>-<PROJECTID>"
+{% else %}
     deliverypath: "{{ item.proj_path }}/<UPPNEXID>/INBOX/<PROJECTID>"
+{% endif %}
     reportpath: <ANALYSISPATH>/piper_ngi
     logpath: <REPORTPATH>/logs
     deliverystatuspath: <REPORTPATH>/08_misc

--- a/roles/taca/templates/site_taca_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_delivery.yml.j2
@@ -6,32 +6,34 @@ deliver:
     analysispath: <ROOTPATH>/ANALYSIS/<PROJECTID>
     datapath: <ROOTPATH>/DATA/<PROJECTID>
     stagingpath: <ROOTPATH>/DELIVERY/<PROJECTID>
-    deliverypath: "{{ item.proj_path }}/<UPPNEXID>/INBOX/<PROJECTID>"
     reportpath: <ANALYSISPATH>/piper_ngi
     logpath: <REPORTPATH>/logs
     deliverystatuspath: <REPORTPATH>/08_misc
     operator: "{{ recipient_mail }}"
     hash_algorithm: md5
 {% if "upps" == site %}
+    deliverypath: "{{ item.proj_path }}/<UPPNEXID>/INBOX/<PROJECTID>"
     report_aggregate: "ngi_reports ign_aggregate_report -n {{ site_full }}"
     report_sample: "ngi_reports ign_sample_report -n {{ site_full }}"
     copy_reports_to_reports_outbox: True
     reports_outbox: "{{ proj_root }}/{{ ngi_pipeline_site_delivery }}/incoming/reports/" 
+{% else %}
+    deliverypath: "{{ item.proj_path }}/<UPPNEXID>/INBOX/<PROJECTNAME>-<PROJECTID>"
 {% endif %}
     files_to_deliver:
-#Adds Sisyphus files to Uppsala deliveries
 {% if "upps" == site %}
+#Adds Sisyphus files to Uppsala deliveries
         -
             - <ANALYSISPATH>/qc_sisyphus/reports
             - <STAGINGPATH>/00-Reports/SequenceQC/Sisyphus
-{% endif %}
-{% if "sthlm" == site %}
+{% elif "sthlm" == site %}
         -
             - <ANALYSISPATH>/reports/*
             - <STAGINGPATH>/00-Reports
 {% endif %}
 #Adds FASTQ files to Lupus (aka irma) deliveries
 {% if "/proj/" == item.proj_path %}
+#Adds FASTQ files to Lupus (aka irma) deliveries
         -
             - <DATAPATH>/<SAMPLEID>/*/*
             - <STAGINGPATH>/<SAMPLEID>/02-FASTQ


### PR DESCRIPTION
Note that this only affects project_summary (which isn't used by uppsala). All other functions will deliver to `pid` as per usual.