### PR TITLE
Arteria-delivery: Call specific version of mover

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port. 
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v1.0.0
+arteria_delivery_version: 75e1b3aa321c50425231aa659460c5d98204fb82
 
 arteria_install_path: "{{ sw_path }}/arteria"
 conda_bin: "{{ sw_path }}/anaconda/bin/conda"
@@ -44,3 +44,4 @@ alembic_path: "{{ arteria_delivery_sources_path }}/alembic/"
 arteria_delivery_port_prod: 10440
 arteria_delivery_port_stage: 10441
 
+mover_path: "/usr/local/mover/1.0.0/"

--- a/roles/arteria-delivery-ws/templates/delivery_app.config.j2
+++ b/roles/arteria-delivery-ws/templates/delivery_app.config.j2
@@ -8,3 +8,4 @@ general_project_directory: {{ project_path }}
 staging_directory: {{ staging_path }}
 port: {{ arteria_delivery_port }}
 alembic_path: {{ alembic_path }}
+path_to_mover: {{ mover_path }}


### PR DESCRIPTION
This change to arteria-delivery calls a specific version of mover (manually set path). To be tested in staging. 