### PR TITLE
 	Start arteria-delivery correctly via supervisord

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ if you want to stage test a specific commit hash of `arteria-checksum`, and the 
 ```
 /lupus/ngi/staging/arteria-staging-FOO/sw/arteria/siswrap_venv/bin/siswrap-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/siswrap/ --port=10431 --debug
 /lupus/ngi/staging/arteria-staging-FOO/sw/arteria/checksum_venv/bin/checksum-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/checksum/ --port=10421 --debug
-/lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/pytohn /lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/delivery-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/delivery/ --port=10441 --debug
+/lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/python /lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/delivery-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/delivery/ --port=10441 --debug
 ```
 
 #### Nota bene

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ if you want to stage test a specific commit hash of `arteria-checksum`, and the 
 ```
 /lupus/ngi/staging/arteria-staging-FOO/sw/arteria/siswrap_venv/bin/siswrap-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/siswrap/ --port=10431 --debug
 /lupus/ngi/staging/arteria-staging-FOO/sw/arteria/checksum_venv/bin/checksum-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/checksum/ --port=10421 --debug
-/lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/pytohn /lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/delivery-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/delivery/ --port=10421 --debug
+/lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/pytohn /lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/delivery-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/delivery/ --port=10441 --debug
 ```
 
 #### Nota bene

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ if you want to stage test a specific commit hash of `arteria-checksum`, and the 
 ```
 /lupus/ngi/staging/arteria-staging-FOO/sw/arteria/siswrap_venv/bin/siswrap-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/siswrap/ --port=10431 --debug
 /lupus/ngi/staging/arteria-staging-FOO/sw/arteria/checksum_venv/bin/checksum-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/checksum/ --port=10421 --debug
-source activate arteria-delivery && exec delivery-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/delivery --port=10441 --debug
+/lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/pytohn /lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/delivery-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/delivery/ --port=10421 --debug
 ```
 
 #### Nota bene

--- a/roles/arteria-delivery-ws/tasks/main.yml
+++ b/roles/arteria-delivery-ws/tasks/main.yml
@@ -43,7 +43,7 @@
     dest="{{ ngi_pipeline_conf }}/supervisord_upps.conf"
     section="program:arteria-delivery-ws-{{ deployment_environment }}"
     option=command
-    value="bash -c 'source activate arteria-delivery && exec delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port }}'"
+    value="{{ arteria_delivery_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port }}"
     backup=no
 
 - name: modify uppsala's supervisord conf to autostart arteria-delivery-ws


### PR DESCRIPTION
Have to start arteria-delivery directly for it to work with supervisord. Also updates the staging example so that it starts in the same way. 