### PR TITLE
Make it easier to stop Kong services

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ if you want to stage test a specific commit hash of `arteria-checksum`, and the 
 
 #### Nota bene
 
-Remember that you will probably have to restart services manually after a new production release have been rolled out. First re-load the crontab as the func user on `irma1` with a `crontab /lupus/ngi/production/latest/conf/crontab_SITE`. Then, depending on what software your func user is running, continue with manually shutting down the old versions and re-start the new versions of the software. 
+Remember that you will probably have to restart services manually after a new production release have been rolled out. First re-load the crontab as the func user on `irma1` with a `crontab /lupus/ngi/production/latest/conf/crontab_SITE`. Then, depending on what software your func user is running, continue with manually shutting down the old versions and re-start the new versions of the software. In the case of Uppsala one should then do a `/lupus/ngi/production/latest/resources/stop_kong.sh` followed by starting `supervisord` and `kong` (see the crontab).  
 
 ### Typical production deployments
 

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -63,3 +63,5 @@
               line='0 1 * * 1 export PATH=/usr/bin/:$PATH && {{ cassandra_dest }}/{{ cassandra_version }}/bin/cqlsh -e "DESC KEYSPACE kong" > {{ cassandra_db_dest }}/kong_schema-`date +%Y%m%d`.cql'
               backup=no
 
+- name: deploy script for easier stoping of kong services
+  template: "stop_kong.sh.j2" dest="{{ ngi_resources }}/stop_kong.sh" mode=g+rwx

--- a/roles/tarzan/templates/stop_kong.sh.j2
+++ b/roles/tarzan/templates/stop_kong.sh.j2
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Killing nginx..."
+export NGINXPID=`ps -u $USER -o %p,%c h | grep nginx | head -1 | cut -d, -f1`
+if [ ! -z $NGINXPID ]; then
+	kill $NGINXPID
+fi
+
+
+echo "Killing serf..."
+export SERFPID=`ps -u $USER -o %p,%c h | grep serf | cut -d, -f1`
+if [ ! -z $SERFPID ]; then
+	kill $SERFPID
+fi
+
+echo "Killing dnsmasq..."
+export DNSPID=`ps -u $USER -o %p,%c h | grep dnsmasq | cut -d, -f1`
+if [ ! -z $DNSPID ]; then
+	kill $DNSPID
+fi
+
+echo "Killing supervisord..."
+export SUPERVISPID=`ps -u $USER -o %p,%c h | grep supervisord | cut -d, -f1`
+if [ ! -z $SUPERVISPID ]; then
+	kill $SUPERVISPID
+fi
+
+sleep 5
+echo "Done."


### PR DESCRIPTION
Just a little script to make it easier to stop the Kong services, so that it is quicker to relaunch them after a new Irma production environment has been rolled out. 