### PR TITLE
Fix parsing of Mover IDs in arteria-delivery

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port. 
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v1.0.2 
+arteria_delivery_version: v1.0.3 
 
 arteria_install_path: "{{ sw_path }}/arteria"
 conda_bin: "{{ sw_path }}/anaconda/bin/conda"

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -64,4 +64,4 @@
               backup=no
 
 - name: deploy script for easier stoping of kong services
-  template: "stop_kong.sh.j2" dest="{{ ngi_resources }}/stop_kong.sh" mode=g+rwx
+  template: src="stop_kong.sh.j2" dest="{{ ngi_resources }}/stop_kong.sh" mode=g+rwx


### PR DESCRIPTION
Use latest version of arteria-delivery that correctly parses the IDs returned from Mover. 

PR also fixes a syntax error in the Tarzan role. 