### PR TITLE
Test latest arteria-delivery

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,8 @@
 #
 # This will set corresponding paths and use the appropriate port. 
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v1.0.3 
+#arteria_delivery_version: v1.0.3 
+arteria_delivery_version: master
 
 arteria_install_path: "{{ sw_path }}/arteria"
 conda_bin: "{{ sw_path }}/anaconda/bin/conda"
@@ -40,6 +41,7 @@ staging_path_prod: "/proj/{{ ngi_pipeline_upps_delivery }}/nobackup/NGI/DELIVERY
 db_path_stage: "/proj/{{ ngi_pipeline_upps_delivery }}/private/db/arteria/staging" 
 db_path_prod: "/proj/{{ ngi_pipeline_upps_delivery }}/private/db/arteria"
 alembic_path: "{{ arteria_delivery_sources_path }}/alembic/"
+delivery_links: "/proj/{{ ngi_pipeline_upps_delivery }}/nobackup/arteria/delivery_project_links"
 
 arteria_delivery_port_prod: 10440
 arteria_delivery_port_stage: 10441

--- a/roles/arteria-delivery-ws/templates/delivery_app.config.j2
+++ b/roles/arteria-delivery-ws/templates/delivery_app.config.j2
@@ -9,3 +9,4 @@ staging_directory: {{ staging_path }}
 port: {{ arteria_delivery_port }}
 alembic_path: {{ alembic_path }}
 path_to_mover: {{ mover_path }}
+project_links_directory: {{ delivery_links }}


### PR DESCRIPTION
Latest `arteria-delivery` includes support for delivering projects consisting of multiple runfolders. For this to work we need a directory where the service can setup symlinks between the relevant sources to include in the delivery. 