### PR TITLE
Workaround for failing PDL dependency tests

### DIFF
--- a/roles/arteria-siswrap-ws/tasks/sisyphus.yml
+++ b/roles/arteria-siswrap-ws/tasks/sisyphus.yml
@@ -35,11 +35,14 @@
 
 - name: install PerlIO::gzip
   cpanm: name=PerlIO::gzip locallib="{{ perllib_dest }}"
-
-  # TODO: this is a pdl dependency that fails 1/32 tests, 
-  # so ignoring this for now due to problems getting it to pass. 
-- name: install Inline::C
-  cpanm: name=Inline::C locallib="{{ perllib_dest }}" notest=yes
+  
+  # TODO: This is a bit hacky, but at the moment we need to skip 
+  # tests for some modules, as otherwise PDL fails to build. 
+- name: manually force-install PDL dependencies that fail tests 
+  cpanm: name="{{ item }}" locallib="{{ perllib_dest }}" notest=yes
+  with_items: 
+    - "Inline::C"
+    - "List::MoreUtils"
 
 - name: install PDL
   cpanm: name=PDL locallib="{{ perllib_dest }}"


### PR DESCRIPTION
An other PDL dependency seems to suddenly fail some of its tests. This workaround just installs the dependency before PDL, and then asks for the tests to be skipped. It might perhaps introduce some weird behaviour downstream (untested), but if that is the case then we'll just have to solve it then. 