### PR TITLE
Start/stop scripts for Arteria staging services

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ python sync.py staging
 
 if you want to stage test a specific commit hash of `arteria-checksum`, and the default version of `arteria-siswrap`. 
 	
-Launching of the Arteria staging services is done by running the command `start-arteria-staging` as the `funk_004` user. That will spawn a detached screen session named `arteria-staging` with one window for each Arteria web service. If a service has crashed then one can (after debugging the stacktrace) respawn the process by hitting the `r` key  for the relevant window. If one want to manually force a restart of the process one can first abort the process with a normal `^C`, followed by the `r` key as mentioned previously. To kill all Arteria services the whole screen session can be closed down with the command `stop-arteria-staging`.  
+Launch the Arteria staging services by running the command `start-arteria-staging` as the `funk_004` user. That will spawn a detached screen session named `arteria-staging` with one window for each Arteria web service. If a service has crashed then one can (after debugging the stacktrace) respawn the process by hitting the `r` key  for the relevant window. If one want to manually force a restart of the process one can first abort the process with a normal `^C`, followed by the `r` key as mentioned previously. To kill all Arteria services the whole screen session can be closed down with the command `stop-arteria-staging`.  
 
 #### Nota bene
 

--- a/README.md
+++ b/README.md
@@ -98,13 +98,9 @@ ansible-playbook install.yml -e deployment_environment=staging -e deployment_ver
 python sync.py staging
 ```
 
-if you want to stage test a specific commit hash of `arteria-checksum`, and the default version of `arteria-siswrap`. When launching the staging services it is recommended to do this inside `screen`, although there are some bundled `supervisord` configs as well. So login to irma1, start a screen session with `screen -S arteria-staging`, and then launch the following commands in separate screen windows: 
-
-```
-/lupus/ngi/staging/arteria-staging-FOO/sw/arteria/siswrap_venv/bin/siswrap-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/siswrap/ --port=10431 --debug
-/lupus/ngi/staging/arteria-staging-FOO/sw/arteria/checksum_venv/bin/checksum-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/checksum/ --port=10421 --debug
-/lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/python /lupus/ngi/staging/arteria-staging-FOO/sw/anaconda/envs/arteria-delivery/bin/delivery-ws --configroot=/lupus/ngi/staging/arteria-staging-FOO/conf/arteria/delivery/ --port=10441 --debug
-```
+if you want to stage test a specific commit hash of `arteria-checksum`, and the default version of `arteria-siswrap`. 
+	
+Launching of the Arteria staging services is done by running the command `start-arteria-staging` as the `funk_004` user. That will spawn a detached screen session named `arteria-staging` with one window for each Arteria web service. If a service has crashed then one can (after debugging the stacktrace) respawn the process by hitting the `r` key  for the relevant window. If one want to manually force a restart of the process one can first abort the process with a normal `^C`, followed by the `r` key as mentioned previously. To kill all Arteria services the whole screen session can be closed down with the command `stop-arteria-staging`.  
 
 #### Nota bene
 

--- a/install.yml
+++ b/install.yml
@@ -33,6 +33,7 @@
     - { role: taca, tags: taca }
     - { role: ngi_reports, tags: ngi_reports }
     - { role: multiqc, tags: multiqc }
+    - { role: arteria-staging, tags: arteria-staging }
     - { role: arteria-checksum-ws, tags: arteria-checksum }
     - { role: arteria-siswrap-ws, tags: arteria-siswrap }
     - { role: arteria-delivery-ws, tags: arteria-delivery }

--- a/roles/arteria-staging/defaults/main.yml
+++ b/roles/arteria-staging/defaults/main.yml
@@ -1,0 +1,1 @@
+arteria_staging_path: "{{ sw_path }}/arteria/arteria_staging/"  

--- a/roles/arteria-staging/defaults/main.yml
+++ b/roles/arteria-staging/defaults/main.yml
@@ -1,1 +1,1 @@
-arteria_staging_path: "{{ sw_path }}/arteria/arteria_staging/"  
+arteria_staging_path: "/lupus/ngi/staging/latest/sw/arteria/arteria_staging/"  

--- a/roles/arteria-staging/meta/main.yml
+++ b/roles/arteria-staging/meta/main.yml
@@ -1,0 +1,6 @@
+dependencies:
+  - { role: arteria-siswrap-ws, tags: arteria-siswrap }
+  - { role: arteria-checksum-ws, tags: arteria-checksum }
+  - { role: arteria-delivery-ws, tags: arteria-delivery }
+  - { role: ngi_pipeline, tags: ngi_pipeline }
+

--- a/roles/arteria-staging/tasks/main.yml
+++ b/roles/arteria-staging/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+
+- name: create arteria-staging folders
+  file: path="{{ item }}"
+        state=directory
+  with_items: 
+    - "{{ arteria_staging_path }}"
+    - "{{ arteria_staging_path }}/bin"
+
+- name: add arteria-staging bin folder to Uppsala path
+  lineinfile: dest="{{ ngi_pipeline_conf }}/{{ bash_env_upps_script }}"
+              line='export PATH={{ arteria_staging_path }}/bin:$PATH'
+              backup=no
+
+- name: deploy arteria-staging screen config
+  template:
+    src: arteria-staging.screen.j2
+    dest: "{{ arteria_staging_path }}/arteria-staging.screen"
+
+- name: deploy start and stop scripts for arteria-staging
+  template: 
+    src: "{{ item }}.j2"
+    dest: "{{ arteria_staging_path }}/bin/{{ item }}"
+    mode: "u=rwx,g=rwx"
+  with_items: 
+    - "start-arteria-staging"
+    - "stop-arteria-staging"

--- a/roles/arteria-staging/templates/arteria-staging.screen
+++ b/roles/arteria-staging/templates/arteria-staging.screen
@@ -1,0 +1,6 @@
+sessionname arteria-staging
+zombie kr
+verbose on
+screen -t checksum 0 bash -i -c "{{ arteria_checksum_env_root }}/bin/checksum-ws --configroot={{ arteria_checksum_config_root }} --port={{ arteria_checksum_port_stage }}  --debug"
+screen -t siswrap 1 bash -i -c "{{ arteria_siswrap_env_root }}/bin/siswrap-ws --configroot={{ arteria_siswrap_config_root }} --port={{ arteria_siswrap_port_stage }} --debug"
+screen -t delivery 2 bash -i -c "{{ arteria_delivery_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/delivery-ws --configroot={{ arteria_delivery_config_root } --port={{ arteria_delivery_port_stage }} --debug"

--- a/roles/arteria-staging/templates/arteria-staging.screen
+++ b/roles/arteria-staging/templates/arteria-staging.screen
@@ -1,6 +1,0 @@
-sessionname arteria-staging
-zombie kr
-verbose on
-screen -t checksum 0 bash -i -c "{{ arteria_checksum_env_root }}/bin/checksum-ws --configroot={{ arteria_checksum_config_root }} --port={{ arteria_checksum_port_stage }}  --debug"
-screen -t siswrap 1 bash -i -c "{{ arteria_siswrap_env_root }}/bin/siswrap-ws --configroot={{ arteria_siswrap_config_root }} --port={{ arteria_siswrap_port_stage }} --debug"
-screen -t delivery 2 bash -i -c "{{ arteria_delivery_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/delivery-ws --configroot={{ arteria_delivery_config_root } --port={{ arteria_delivery_port_stage }} --debug"

--- a/roles/arteria-staging/templates/arteria-staging.screen.j2
+++ b/roles/arteria-staging/templates/arteria-staging.screen.j2
@@ -1,0 +1,6 @@
+sessionname arteria-staging
+zombie kr
+verbose on
+screen -t checksum 0 bash -i -c "{{ arteria_checksum_env_root }}/bin/checksum-ws --configroot={{ arteria_checksum_config_root }} --port={{ arteria_checksum_port_stage }}  --debug"
+screen -t siswrap 1 bash -i -c "{{ arteria_siswrap_env_root }}/bin/siswrap-ws --configroot={{ arteria_siswrap_config_root }} --port={{ arteria_siswrap_port_stage }} --debug"
+screen -t delivery 2 bash -i -c "{{ arteria_delivery_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port_stage }} --debug"

--- a/roles/arteria-staging/templates/start-arteria-staging.j2
+++ b/roles/arteria-staging/templates/start-arteria-staging.j2
@@ -1,0 +1,2 @@
+#!/bin/sh
+screen -d -m -c {{ arteria_staging_path }}/arteria-staging.screen

--- a/roles/arteria-staging/templates/stop-arteria-staging.j2
+++ b/roles/arteria-staging/templates/stop-arteria-staging.j2
@@ -1,0 +1,3 @@
+#!/bin/sh
+screen -S arteria-staging -X quit
+


### PR DESCRIPTION
This will make it somewhat easier to start/stop Arteria staging services. 

Note that in this variant the screen will start a specific version of the services. Which version that gets started is decided by what the current production environment sets in `PATH`. To make it possible to iterate through many staging versions while not having to update the production environment we're therefore setting `PATH` to `../staging/latest/`. 


