### PR TITLE
remove unwanted alias for ngi-methylseq

### DIFF
--- a/roles/ngi-methylseq/tasks/main.yml
+++ b/roles/ngi-methylseq/tasks/main.yml
@@ -27,15 +27,7 @@
 
 - name: Set Methylseq Bismark alias
   lineinfile: dest="{{ ngi_pipeline_conf }}/{{ item.script }}"
-              line="alias bis-meth='nextflow {{ ngi_methylseq_dest }}/bismark.nf -c {{ ngi_pipeline_conf }}/ngi-methylseq_{{ item.site }}.config'"
-              backup=no
-  with_items:
-  - { site: "sthlm", script: "{{ bash_env_sthlm_script }}" }
-  - { site: "upps", script: "{{ bash_env_upps_script }}" }
-
-- name: Set Methylseq BVA alias
-  lineinfile: dest="{{ ngi_pipeline_conf }}/{{ item.script }}"
-              line="alias bva-meth='nextflow {{ ngi_methylseq_dest }}/bva-meth.nf -c {{ ngi_pipeline_conf }}/ngi-methylseq_{{ item.site }}.config'"
+              line="alias methylseq='nextflow run {{ ngi_methylseq_dest }}/bismark.nf -c {{ ngi_pipeline_conf }}/ngi-methylseq_{{ item.site }}.config'"
               backup=no
   with_items:
   - { site: "sthlm", script: "{{ bash_env_sthlm_script }}" }


### PR DESCRIPTION
Only bismark will be used for production, so @ewels prefer just one alias. This is something not urgent so will be included in next release.