### PR TITLE
Increase the performance slightly

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,8 @@
 #remote_tmp=/tmp/
 log_path=/lupus/ngi/irma3/log/ansible.log
 retry_files_enabled=false
+
+[ssh_connection]
+pipelining=True
+ssh_args=-o ControlMaster=auto -o ControlPersist=60m
+


### PR DESCRIPTION
This will increase the performance of Ansible slightly. As default it only keeps the SSH connections open for 1 minute, so lets increase it to 60 minutes. Pipelining reduces the number of SSH operations required for executing a module. Can cause problems when combined with sudo, but that's not an issue for us. 
