### PR TITLE
remove path to exclude from archive

### DIFF
--- a/roles/archive-upload-ws/templates/archive_upload_app.config.j2
+++ b/roles/archive-upload-ws/templates/archive_upload_app.config.j2
@@ -40,5 +40,5 @@ whitelisted_warnings: "{{ archive_upload_whitelisted_warnings }}"
 # Dirs and file extensions to exclude from the _archive copy of the runfolder/project
 exclude_dirs: [""]
 exclude_extensions: [".bam"]
-# # Elements to exclude from the tarball of the _archive dir, only on biotank. 
-exclude_from_tarball: [""]
+# # Elements to exclude from the tarball of the _archive dir
+exclude_from_tarball: []


### PR DESCRIPTION
remove empty path from exclude_from_tarball list which caused everything to be excluded