### PR TITLE
kong/lua: fix broken kong deployment

### DIFF
--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -5,6 +5,7 @@ tarzan_conf: "{{ ngi_pipeline_conf }}/tarzan/"
 
 ## Paths for all sw to download and later build 
 
+kong_dest: "{{ tarzan_dest }}/kong/"
 kong_version: 0.12.3
 # Not needed anymore. 
 #kong_url: https://github.com/Mashape/kong/archive/0.7.0.tar.gz
@@ -12,11 +13,6 @@ kong_version: 0.12.3
 #kong_dest: "{{ tarzan_dest }}/kong/"
 
 # kong depends on the lua eco system
-luajit_url: http://luajit.org/download/LuaJIT-2.1.0-beta2.tar.gz
-luajit_file: LuaJIT-2.1.0-beta2.tar.gz
-luajit_version: 2.1.0-beta2
-luajit_dest: "{{ tarzan_dest }}/luajit/"
-
 luarocks_url: http://luarocks.org/releases/luarocks-2.4.3.tar.gz 
 luarocks_file: luarocks-2.4.3.tar.gz
 luarocks_version: 2.4.3
@@ -48,7 +44,7 @@ serf_dest: "{{ tarzan_dest }}/serf"
 
 ## Settings for relevant sw
 
-tarzan_env_path: "{{ luajit_dest }}/{{ luajit_version }}/bin:{{ luarocks_dest }}/{{ luarocks_version }}/bin:{{ openresty_dest }}/{{ openresty_version }}/bin:{{ cassandra_dest }}/{{ cassandra_version }}/bin/:{{ serf_dest }}/:{{ openresty_dest }}/{{ openresty_version }}/nginx/sbin"
+tarzan_env_path: "{{ openresty_dest }}/{{ openresty_version }}/luajit/bin:{{ luarocks_dest }}/{{ luarocks_version }}/bin:{{ openresty_dest }}/{{ openresty_version }}/bin:{{ cassandra_dest }}/{{ cassandra_version }}/bin/:{{ serf_dest }}/:{{ openresty_dest }}/{{ openresty_version }}/nginx/sbin"
 
 tarzan_log_dest: "{{ ngi_pipeline_upps_path }}/log/tarzan/"
 tarzan_db_dest: "{{ ngi_pipeline_upps_path }}/db/tarzan/"
@@ -62,5 +58,5 @@ cassandra_db_dest: "{{ tarzan_db_dest }}/cassandra"
 # get warnings the module system lmod which is using lua as well. This 
 # might be a future error source.
 lua_path: "/home/funk_004/.luarocks/share/lua/5.1/?.lua;/home/funk_004/.luarocks/share/lua/5.1/?/init.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/?.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/?/init.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/*/init.lua;;/usr/share/lua/5.1/?.lua;/usr/share/lua/5.1/?/init.lua"
-lua_cpath: "/home/funk_004/.luarocks/lib/lua/5.1/?.so;{{ luarocks_dest }}/{{ luarocks_version }}/lib/lua/5.1/?.so;./?.so;/usr/local/lib/lua/5.1/?.so;{{ luajit_dest }}/{{ luajit_version }}/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so;/usr/lib64/lua/5.1/?.so;/usr/lib64/lua/5.1/loadall.so"
+lua_cpath: "/home/funk_004/.luarocks/lib/lua/5.1/?.so;{{ luarocks_dest }}/{{ luarocks_version }}/lib/lua/5.1/?.so;./?.so;/usr/local/lib/lua/5.1/?.so;{{ openresty_dest }}/{{ openresty_version }}/luajit/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so;/usr/lib64/lua/5.1/?.so;/usr/lib64/lua/5.1/loadall.so"
 

--- a/roles/tarzan/tasks/dependencies.yml
+++ b/roles/tarzan/tasks/dependencies.yml
@@ -1,74 +1,12 @@
 ---
-# kong demands: 
-# luajit
+# kong demands:
+# openssl sources
+# openresty (comes with luajit)
 # luarocks
-# openresty
 # cassandra
 # serf
 
 # use a loop a la http://stackoverflow.com/questions/30785281/one-loop-over-multiple-ansible-tasks ? 
-
-- name: create luajit destination directory 
-  file: path={{ luajit_dest }} state=directory mode=g+rwXs
-
-- name: download luajit archive
-  get_url:
-    url: "{{ luajit_url }}"
-    dest: "{{ luajit_dest }}/{{ luajit_file }}"
-
-- name: unpack luajit to destination
-  unarchive: 
-    src: "{{ luajit_dest }}/{{ luajit_file }}" 
-    dest: "{{ luajit_dest }}"
-    copy: no 
-    creates: "{{ luajit_dest }}/{{ luajit_version }}/bin/luajit-{{ luajit_version }}"
-    mode: g+rwX,o+rX
-
-- name: set luajits install path
-  lineinfile: dest="{{ luajit_dest }}/LuaJIT-{{ luajit_version }}/Makefile"
-              regexp="^export PREFIX=./usr/local"
-              line='export PREFIX={{ luajit_dest }}/{{ luajit_version }}'
-              backup=no
-
-- name: compile luajit 
-  shell: make install
-  args: 
-    chdir: "{{ luajit_dest }}/LuaJIT-{{ luajit_version }}"
-    creates: "{{ luajit_dest }}/{{ luajit_version }}/bin/luajit-{{ luajit_version }}"
-
-- name: symlink lua to luajit-version binary
-  file: src="{{ luajit_dest }}/{{ luajit_version }}/bin/luajit-{{ luajit_version }}" path="{{ luajit_dest }}/{{ luajit_version }}/bin/lua" state=link
-
-- name: symlink luajit to luajit-version binary
-  file: src="{{ luajit_dest }}/{{ luajit_version }}/bin/luajit-{{ luajit_version }}" path="{{ luajit_dest }}/{{ luajit_version }}/bin/luajit" state=link
-
-- name: create luarocks destination directory
-  file: path={{ luarocks_dest }} state=directory mode=g+rwXs
-
-- name: download luarocks archive
-  get_url:
-    url: "{{ luarocks_url }}"
-    dest: "{{ luarocks_dest }}/{{ luarocks_file }}"
-
-- name: unpack luarocks to destination
-  unarchive: 
-    src: "{{ luarocks_dest }}/{{ luarocks_file }}" 
-    dest: "{{ luarocks_dest }}"
-    copy: no 
-    creates: "{{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks"
-    mode: g+rwX,o+rX
-
-- name: configure luarocks
-  shell: "./configure --with-lua={{ luajit_dest }}/{{ luajit_version }} --with-lua-include={{ luajit_dest }}/{{ luajit_version }}/include/luajit-2.1 --prefix={{ luarocks_dest }}/{{ luarocks_version }}"
-  args: 
-    chdir: "{{ luarocks_dest }}/luarocks-{{ luarocks_version }}"
-    creates: "{{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks"
-
-- name: compile luarocks 
-  shell: make build && make install
-  args: 
-    chdir: "{{ luarocks_dest }}/luarocks-{{ luarocks_version }}"
-    creates: "{{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks"
 
 - name: create openssl destination directory
   file: path={{ openssl_dest }} state=directory mode=g+rwXs
@@ -103,7 +41,7 @@
     mode: g+rwX,o+rX
 
 - name: configure openresty
-  shell: "./configure --with-pcre-jit --with-ipv6 --with-http_realip_module --with-http_ssl_module --with-http_stub_status_module --with-luajit={{ luajit_dest }}/{{ luajit_version }} --prefix={{ openresty_dest }}/{{ openresty_version }} --with-openssl={{ openssl_dest }}/openssl-{{ openssl_version }}/" 
+  shell: "./configure --with-pcre-jit --with-ipv6 --with-http_realip_module --with-http_ssl_module --with-http_stub_status_module --with-http_v2_module --prefix={{ openresty_dest }}/{{ openresty_version }} --with-openssl={{ openssl_dest }}/openssl-{{ openssl_version }}/" 
   args: 
     chdir: "{{ openresty_dest }}/openresty-{{ openresty_version }}"
     creates: "{{ openresty_dest }}/{{ openresty_version }}/bin/resty"
@@ -113,6 +51,34 @@
   args: 
     chdir: "{{ openresty_dest}}/openresty-{{ openresty_version }}" 
     creates: "{{ openresty_dest }}/{{ openresty_version }}/bin/resty"
+
+- name: create luarocks destination directory
+  file: path={{ luarocks_dest }} state=directory mode=g+rwXs
+
+- name: download luarocks archive
+  get_url:
+    url: "{{ luarocks_url }}"
+    dest: "{{ luarocks_dest }}/{{ luarocks_file }}"
+
+- name: unpack luarocks to destination
+  unarchive: 
+    src: "{{ luarocks_dest }}/{{ luarocks_file }}" 
+    dest: "{{ luarocks_dest }}"
+    copy: no 
+    creates: "{{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks"
+    mode: g+rwX,o+rX
+
+- name: configure luarocks
+  shell: "./configure --lua-suffix=jit --with-lua={{ openresty_dest }}/{{ openresty_version }}/luajit --with-lua-include={{ openresty_dest }}/{{ openresty_version }}/luajit/include/luajit-2.1 --prefix={{ luarocks_dest }}/{{ luarocks_version }}"
+  args: 
+    chdir: "{{ luarocks_dest }}/luarocks-{{ luarocks_version }}"
+    creates: "{{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks"
+
+- name: compile luarocks 
+  shell: make build && make install
+  args: 
+    chdir: "{{ luarocks_dest }}/luarocks-{{ luarocks_version }}"
+    creates: "{{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks"
 
 - name: create cassandra destination directory
   file: path={{ cassandra_dest }} state=directory mode=g+rwXs

--- a/roles/tarzan/tasks/dependencies.yml
+++ b/roles/tarzan/tasks/dependencies.yml
@@ -68,8 +68,20 @@
     creates: "{{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks"
     mode: g+rwX,o+rX
 
+- name: figure out luajit version/include folder name
+  find:
+    paths: "{{ openresty_dest }}/{{ openresty_version }}/luajit/include"
+    patterns: "luajit-*"
+    recurse: no
+    file_type: directory
+  register: luajit_include_folder
+
+- name: make sure the include folder is unambiguous
+  assert:
+    that: "luajit_include_folder.matched == 1"
+
 - name: configure luarocks
-  shell: "./configure --lua-suffix=jit --with-lua={{ openresty_dest }}/{{ openresty_version }}/luajit --with-lua-include={{ openresty_dest }}/{{ openresty_version }}/luajit/include/luajit-2.1 --prefix={{ luarocks_dest }}/{{ luarocks_version }}"
+  shell: "./configure --lua-suffix=jit --with-lua={{ openresty_dest }}/{{ openresty_version }}/luajit --with-lua-include={{ luajit_include_folder.files[0].path }} --prefix={{ luarocks_dest }}/{{ luarocks_version }}"
   args: 
     chdir: "{{ luarocks_dest }}/luarocks-{{ luarocks_version }}"
     creates: "{{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks"

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -8,8 +8,27 @@
 
 - include: dependencies.yml 
 
+# when installing with luarocks, the startup script is no longer created
+# therefore we install from source. The Makefile uses luarocks for
+# installation, so there is no big difference there, but it also allows us
+# to copy the startup script manually
+- name: get kong sources
+  git:
+    repo: https://github.com/Kong/kong
+    version: "{{ kong_version }}"
+    dest: "{{ kong_dest }}"
+
 - name: install kong via luarocks
-  shell: "export PATH={{ tarzan_env_path }}:$PATH && luarocks install kong {{ kong_version }}-0"
+  shell: "export PATH={{ tarzan_env_path }}:$PATH && make install"
+  args:
+    chdir: "{{ kong_dest }}"
+
+- name: copy kong's start script
+  copy:
+    src: "{{ kong_dest }}/bin/kong"
+    dest: "{{ luarocks_dest }}/{{ luarocks_version }}/bin"
+    remote_src: yes
+    mode: 0775
 
 - name: add the kong paths to funk_004's environment via the sourceme_upps script 
   lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_upps_script }}


### PR DESCRIPTION
Kong does no longer generate its start script in the bin directory of
the lua runtime when installed via luarocks. So instead we install from
source, which for the most part does the exact same thing
Meanwhile, according to the kong docs
(https://getkong.org/install/source/), it is recommended to use the lua
runtime that comes with openresty. So I also reordered the installation process a little and removed installing the standalone luajit.