### PR TITLE
LOG versions for tools installed within deployment

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -66,5 +66,8 @@ validation_data:
  - "160915_ST-1234_0123_ATESTFCCXX"
  - "160915_ST-1234_0124_BCHR22CCXX"
 
+# File with tools/software version in the deployed env
+deployed_tool_versions: "{{ ngi_resources }}/deployed_tools.version"
+
 # Empty placeholder that gets filled by tasks/pre-install.yml
 root_path: 

--- a/roles/archive-upload-ws/tasks/main.yml
+++ b/roles/archive-upload-ws/tasks/main.yml
@@ -22,3 +22,7 @@
 
 - include: 2_install_config.yml
 
+- name: Store archive-upload-ws tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "snpseq-archive-upload: {{ archive_upload_version }}"

--- a/roles/arteria-checksum-ws/tasks/main.yml
+++ b/roles/arteria-checksum-ws/tasks/main.yml
@@ -22,3 +22,7 @@
 
 - include: 2_install_config.yml
 
+- name: Store arteria-checksum-ws tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "arteria-checksum: {{ arteria_checksum_version }}"

--- a/roles/arteria-delivery-ws/tasks/main.yml
+++ b/roles/arteria-delivery-ws/tasks/main.yml
@@ -54,3 +54,7 @@
     value=true
     backup=no
 
+- name: Store arteria-delivery-ws tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "arteria-delivery: {{ arteria_delivery_version }}"

--- a/roles/arteria-siswrap-ws/tasks/main.yml
+++ b/roles/arteria-siswrap-ws/tasks/main.yml
@@ -55,3 +55,7 @@
               line="export PERL5LIB={{ ngi_resources }}/arteria/perl/lib/perl5/:$PERL5LIB"
               backup=no
 
+- name: Store arteria-siswrap-ws tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "arteria-siswrap: {{ arteria_siswrap_version }}"

--- a/roles/arteria-siswrap-ws/tasks/sisyphus.yml
+++ b/roles/arteria-siswrap-ws/tasks/sisyphus.yml
@@ -79,3 +79,8 @@
 - name: setup link to sisyphus latest
   file: state=link src="{{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }}" dest="{{ sisyphus_path }}/sisyphus-latest" mode=775
 
+- name: Store sisyphus tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "sisyphus: {{ sisyphus_version.stdout }}"
+  when: "'{{ sisyphus_version.stdout }}'"

--- a/roles/methylseq/tasks/main.yml
+++ b/roles/methylseq/tasks/main.yml
@@ -33,3 +33,7 @@
   - { site: "sthlm", script: "{{ bash_env_sthlm_script }}" }
   - { site: "upps", script: "{{ bash_env_upps_script }}" }
 
+- name: Store methylseq tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "methylseq: {{ methylseq_version }}"

--- a/roles/multiqc/tasks/main.yml
+++ b/roles/multiqc/tasks/main.yml
@@ -36,3 +36,11 @@
   with_items:
   - { site: "sthlm", script: "{{ bash_env_sthlm_script }}", flags: "-t ngi"}
   - { site: "upps", script: "{{ bash_env_upps_script }}", flags: "" }
+
+- name: Store MultiQC tool version in deployement
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "{{ item.tool_name }}: {{ item.tool_version }}"
+  with_items:
+    - { tool_name: "MultiQC", tool_version: "{{ multiqc_version }}" }
+    - { tool_name: "MultiQC_NGI", tool_version: "{{ multiqc_ngi_version }}" }

--- a/roles/nextflow/tasks/main.yml
+++ b/roles/nextflow/tasks/main.yml
@@ -51,3 +51,7 @@
 # Path to java to be used for nextflow
   - { envvar: "export NXF_JAVA_HOME={{ nextflow_java }}"}
 
+- name: Store nextflow version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "Nextflow: {{ nextflow_ver.stdout }}"

--- a/roles/ngi-neutronstar/tasks/main.yml
+++ b/roles/ngi-neutronstar/tasks/main.yml
@@ -36,3 +36,7 @@
          --clusterOptions="-A {{ ngi_pipeline_sthlm_delivery }} -p node" --max_memory 250'
      backup: no
 
+- name: Store ngi-neutronstar tool version in deployement
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "NGI-neutronStar: {{ neutronstar_version }}"

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -111,10 +111,13 @@
   ignore_errors: true
 
 - name: Store anaconda version in deployment
-  lineinfile: dest="{{ deployed_tool_versions }}"
-              line="Anaconda: {{ conda_version.stdout }}"
-  when: "{{ conda_version.stdout }}"
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "Anaconda: {{ conda_version.stderr }}"
+  when: "'{{ conda_version.stderr }}'" #for some reason saved as stderr
 
 - name: Store ngi_pipeline version in deployment
-  lineinfile: dest="{{ deployed_tool_versions }}"
-              line="NGI Pipeline: {{ ngi_pipeline_version }}"
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "NGI Pipeline: {{ ngi_pipeline_version }}"
+

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -43,7 +43,9 @@
   file: name="{{ ngi_resources }}/piper" state=directory mode=g+s
 
 - name: Create deployed tools version file
-  file: name="{{ deployed_tool_versions }}" state=touch
+  copy:
+    dest: "{{ deployed_tool_versions }}"
+    content: "-- {{ deployment_environment }} ({{ deployment_version }}) --"
 
 - name: Deploy GATK license key 
   copy: src="files/{{ gatk_key }}" dest="{{ ngi_resources }}/piper/{{ gatk_key }}"

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -42,6 +42,9 @@
 - name: Create ngi_resources/piper folder
   file: name="{{ ngi_resources }}/piper" state=directory mode=g+s
 
+- name: Create deployed tools version file
+  file: name="{{ deployed_tool_versions }}" state=touch
+
 - name: Deploy GATK license key 
   copy: src="files/{{ gatk_key }}" dest="{{ ngi_resources }}/piper/{{ gatk_key }}"
 
@@ -102,3 +105,16 @@
               line='export PATH={{ anaconda_path }}/bin:$PATH'
               backup=no
 
+- name: Try getting anaconda version
+  shell: "conda --version"
+  register: conda_version
+  ignore_errors: true
+
+- name: Store anaconda version in deployment
+  lineinfile: dest="{{ deployed_tool_versions }}"
+              line="Anaconda: {{ conda_version.stdout }}"
+  when: "{{ conda_version.stdout }}"
+
+- name: Store ngi_pipeline version in deployment
+  lineinfile: dest="{{ deployed_tool_versions }}"
+              line="NGI Pipeline: {{ ngi_pipeline_version }}"

--- a/roles/ngi_reports/tasks/main.yml
+++ b/roles/ngi_reports/tasks/main.yml
@@ -34,3 +34,11 @@
   with_items:
   - { site: "upps", env_script: "{{ bash_env_upps_script }}" }
   - { site: "sthlm", env_script: "{{ bash_env_sthlm_script }}" }
+
+- name: Store ngi_reports tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "{{ item.tool_name }}: {{ item.tool_version }}"
+  with_items:
+    - { tool_name: "ngi_reports", tool_version: "{{ ngi_reports_version }}" }
+    - { tool_name: "ngi_visualizations", tool_version: "{{ ngi_visual_version }}" } 

--- a/roles/nougat/tasks/main.yml
+++ b/roles/nougat/tasks/main.yml
@@ -22,3 +22,12 @@
   lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_sthlm_script }}
               line="export NOUGAT_CONF={{ ngi_pipeline_conf }}/NouGAT_config.conf"
               backup=no
+
+- name: Store nougat tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "{{ item.tool_name }}: {{ item.tool_version }}"
+  with_items:
+    - { tool_name: "NouGAT", tool_version: "{{ nougat_version }}" }
+    - { tool_name: "KmerGenie", tool_version: "{{ kmer_version }}" }
+    - { tool_name: "FRC_align", tool_version: "{{ frc_align_version }}" }

--- a/roles/rnaseq/tasks/main.yml
+++ b/roles/rnaseq/tasks/main.yml
@@ -45,3 +45,8 @@
   with_items:
   - { site: "sthlm", script: "{{ bash_env_sthlm_script }}" }
   - { site: "upps", script: "{{ bash_env_upps_script }}" }
+
+- name: Store rnaseq tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "rnaseq: {{ rnaseq_version }}"

--- a/roles/sarek/tasks/main.yml
+++ b/roles/sarek/tasks/main.yml
@@ -44,3 +44,8 @@
   with_items:
   - { site: "sthlm", script: "{{ bash_env_sthlm_script }}" }
   - { site: "upps", script: "{{ bash_env_upps_script }}" }
+
+- name: Store SAREK tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "sarek: {{ sarek_version }}"

--- a/roles/taca/tasks/main.yml
+++ b/roles/taca/tasks/main.yml
@@ -56,3 +56,12 @@
   template: src="site_app_specific_delivery.yml.j2" dest="{{ ngi_pipeline_conf }}/TACA/{{ site }}_taca_{{ item }}_delivery.yml"
   with_items: ['rna', 'denovo']
 
+- name: Store taca tools version on deployement
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "{{ item.tool_name }}: {{ item.tool_version }}"
+  with_items:
+    - { tool_name: "TACA", tool_version: "{{ taca_version }}" }
+    - { tool_name: "taca-ngi-pipeline", tool_version: "{{ taca_ngi_version }}" }
+    - { tool_name: "StatusDB", tool_version: "{{ statusdb_version }}" }
+    - { tool_name: "flowcell_parser", tool_version: "{{ flowcell_parser_version }}" }

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -84,3 +84,14 @@
 
 - name: deploy script for easier stoping of kong services
   template: src="stop_kong.sh.j2" dest="{{ ngi_resources }}/stop_kong.sh" mode=g+rwx
+
+- name: Store tarzan tools version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "{{ item.tool_name }}: {{ item.tool_version }}"
+  with_items:
+    - { tool_name: "Kong", tool_version: "{{ kong_version }}" }
+    - { tool_name: "Luarocks", tool_version: "{{ luarocks_version }}" }
+    - { tool_name: "Cassandra", tool_version: "{{ cassandra_version }}" }
+    - { tool_name: "Openresty", tool_version: "{{ openresty_version }}" }
+    - { tool_name: "Serf", tool_version: "{{ serf_version }}" }

--- a/roles/ugc/tasks/main.yml
+++ b/roles/ugc/tasks/main.yml
@@ -25,3 +25,15 @@
 - name: deploy ugc bash env file 
   template: src="sourceme_ugc.sh.j2" dest="{{ ngi_pipeline_conf }}/sourceme_ugc.sh"
 
+- name: try to get ugc-delivery commit version
+  command: git rev-parse HEAD
+  args:
+    chdir: "{{ delivery_src }}"
+  register: delivery_version
+  ignore_errors: true
+
+- name: Store ugc-delivery tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "ugc-delivery: {{ delivery_version.stdout }}"
+  when: "'{{ delivery_version.stdout }}'"

--- a/tasks/post-install.yml
+++ b/tasks/post-install.yml
@@ -31,11 +31,11 @@
     # not using 'blockinline' to avoid ansible markers
     - name: Create alias 'deployed_env'
       lineinfile:
-        dest: "{{ bash_env_script }}"
+        dest: "{{ ngi_pipeline_conf }}/{{ bash_env_script }}"
         line: "{{ item }}"
       with_items:
         - "#alias to get versions for tools installed in the current deployment"
-        - "alias deployed_env='echo \"$IRMA_ENV ($IRMA_VER)\" && cat {{ deployed_tool_versions }}'"
+        - "alias deployed_env='cat {{ deployed_tool_versions }}'"
 
   - debug: msg="Finished deploying to {{ root_path }}"
 

--- a/tasks/post-install.yml
+++ b/tasks/post-install.yml
@@ -25,6 +25,17 @@
     - name: Make wildwest directory editable by anyone that can access irma
       shell: "find {{ proj_root }} -user `whoami` -exec chmod g+rwXs,o=rwX {} \\;"
     when: deployment_environment == "staging"
+  
+  - block:
+    # Create an alias to easily get the deployed tools version
+    # not using 'blockinline' to avoid ansible markers
+    - name: Create alias 'deployed_env'
+      lineinfile:
+        dest: "{{ bash_env_script }}"
+        line: "{{ item }}"
+      with_items:
+        - "#alias to get versions for tools installed in the current deployment"
+        - "alias deployed_env='echo \"$IRMA_ENV ($IRMA_VER)\" && cat {{ deployed_tool_versions }}'"
 
   - debug: msg="Finished deploying to {{ root_path }}"
 

--- a/tasks/post-install.yml
+++ b/tasks/post-install.yml
@@ -21,12 +21,21 @@
     when: deployment_environment != "devel" 
 
   - block:
-
     - name: Make wildwest directory editable by anyone that can access irma
       shell: "find {{ proj_root }} -user `whoami` -exec chmod g+rwXs,o=rwX {} \\;"
     when: deployment_environment == "staging"
   
   - block:
+    - name: Try to get irma_provision latest version
+      command: git rev-parse HEAD
+      register: irma_provision_version
+
+    - name: Add irma_provision version to deployed tools files
+      lineinfile:
+        dest: "{{ deployed_tool_versions }}"
+        line: "-- Deployed at {{ ansible_date_time.iso8601 }} by irma_provision ({{ irma_provision_version.stdout }}) --"
+      when: "'{{ irma_provision_version.stdout }}'"
+
     # Create an alias to easily get the deployed tools version
     # not using 'blockinline' to avoid ansible markers
     - name: Create alias 'deployed_env'


### PR DESCRIPTION
As discussed with @b97pla , this is a preliminary way (in future can be extend to make it fancier with more info) to have tool versions within the deployed environment. It also creates an `alias` called `deploy_env` to fetch that info easily

```
[~$] deployed_env
-- devel (default) --
Anaconda: conda 4.1.6
NGI Pipeline: 061dc824237e1b95aca76d1c0ecfea0108c779f7
Nextflow: 0.31.1
Kong: 0.12.3
Luarocks: 2.4.3
Cassandra: 2.2.5
Openresty: 1.11.2.5
Serf: 0.7.0
TACA: 30a256ef7fc40c8ceaf199145ae1fa7a34cdc4b9
taca-ngi-pipeline: c6b803b3e9e116294387ec83e6fd96cece6737aa
StatusDB: ca2a3faea82a10359c70f7a7697db499b5c82b17
flowcell_parser: e4750ce700026b1e7427de712d1464049d222a88
ngi_reports: c782f7b97f8e9f672af9ae18d5426b20cb13a77b
ngi_visualizations: 1bdc2d51d8588ec3067ada873adadb0aa661251d
MultiQC: v1.6
MultiQC_NGI: v0.6
sisyphus: v16.2.0
arteria-siswrap: v1.1.0
arteria-checksum: v1.0.3
arteria-delivery: v2.1.0
sarek: c63d8134bbec0cf72c534e16bd8f43c932b02193
rnaseq: 1.0
methylseq: 1.1
NGI-neutronStar: c92ce0d99baff39bfcbb36c64be03160dc0331f8
NouGAT: 93e376d957dcf6f51d850febdec7f117b703b290
KmerGenie: kmergenie-1.7039
FRC_align: 5b3f53e01cb539c857fd4230ec9410d76220fe22
ugc-delivery: bd7f23d453368ec389725dfa09199c2f0c95b882
snpseq-archive-upload: v1.0.0-rc1
```