### PR TITLE
bump archive-upload version, include necessary parameters

### DIFF
--- a/roles/archive-upload-ws/defaults/main.yml
+++ b/roles/archive-upload-ws/defaults/main.yml
@@ -8,7 +8,7 @@
 # This will set corresponding paths and use the appropriate port.  
 
 archive_upload_repo: https://github.com/Molmed/snpseq-archive-upload.git
-archive_upload_version: v1.0.0-rc1
+archive_upload_version: v1.0.0
 
 # in production this should be  /proj/ngi2016001/nobackup/NGI/ANALYSIS/<PROJECT ID>
 archive_upload_monitored_path_prod: "/proj/{{ ngi_pipeline_upps_delivery }}/nobackup/NGI/ANALYSIS/"
@@ -39,3 +39,6 @@ archive_upload_virtual_env_command: "/usr/bin/python /lupus/ngi/irma3/virtualenv
 # ANS2042W = a symblic link to a file on other fs has been uploaded: acls/extended attributes might not be backed up
 # ANS2250W = a TSM core file or crash report was found
 archive_upload_whitelisted_warnings: ["ANS1809W", "ANS2042W", "ANS2250W"]
+archive_upload_exclude_dirs: []
+archive_upload_exclude_extensions: [".bam"]
+archive_upload_exclude_from_tarball: []

--- a/roles/archive-upload-ws/templates/archive_upload_app.config.j2
+++ b/roles/archive-upload-ws/templates/archive_upload_app.config.j2
@@ -33,12 +33,12 @@ log_directory: "{{ archive_upload_log_dir }}"
 # jobs to succeed. 
 #
 # See full list at e.g. https://www.ibm.com/support/knowledgecenter/en/SSGSG7_7.1.1/com.ibm.itsm.msgs.client.doc/msgs_client_list_intro.html
-whitelisted_warnings: "{{ archive_upload_whitelisted_warnings }}"
+whitelisted_warnings: {{ archive_upload_whitelisted_warnings | to_json }}
 
 # Exclude filters (different on biotank and Irma) 
 #
 # Dirs and file extensions to exclude from the _archive copy of the runfolder/project
-exclude_dirs: [""]
-exclude_extensions: [".bam"]
+exclude_dirs: {{ archive_upload_exclude_dirs | to_json }}
+exclude_extensions: {{ archive_upload_exclude_extensions | to_json }}
 # # Elements to exclude from the tarball of the _archive dir
-exclude_from_tarball: []
+exclude_from_tarball: {{ archive_upload_exclude_from_tarball | to_json }}


### PR DESCRIPTION
This PR updates the current version of the archive-upload arteria micro service to 1.0.0 and adds some necessary config parameters