### PR TITLE
ngi_pipeline set qc make_md5

### DIFF
--- a/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
+++ b/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
@@ -97,6 +97,7 @@ qc:
             - fastq_screen
         subsample_reads: 200000
         threads: 1
+        make_md5: True
 
 gt_concordance:
     XL_FILES_PATH: {{ proj_root }}/{{ ngi_pipeline_slurm_project }}/genotype_data/incoming


### PR DESCRIPTION
This config change is relevant to this [PR](https://github.com/NationalGenomicsInfrastructure/ngi_pipeline/pull/380)