### PR TITLE
Updated snpseq-archive-upload to v1.0.1

### DIFF
--- a/roles/archive-upload-ws/defaults/main.yml
+++ b/roles/archive-upload-ws/defaults/main.yml
@@ -8,7 +8,7 @@
 # This will set corresponding paths and use the appropriate port.  
 
 archive_upload_repo: https://github.com/Molmed/snpseq-archive-upload.git
-archive_upload_version: v1.0.0
+archive_upload_version: v1.0.1
 
 # in production this should be  /proj/ngi2016001/nobackup/NGI/ANALYSIS/<PROJECT ID>
 archive_upload_monitored_path_prod: "/proj/{{ ngi_pipeline_upps_delivery }}/nobackup/NGI/ANALYSIS/"


### PR DESCRIPTION
Every time snpseq-archive-upload is called with the upload or reupload endpoint a dsmc command is started and the output of this command is written to a dsmc_output-file. However, old errors from previous uploading or reuploading can cause issues when we later parse this log for errors. Release v.1.0.1 of snpseq-archive-upload includes a fix where a new log file is created when the service is called and the old log file is moved to a new file with a timestamp.

This fix is not tested thoroughly in staging environment. However, snpseq_packs.archive_upload_workflow and snpseq_packs.archive_missing_files_workflow runs without errors on mm-xart001 with the service running on mm-xart002.