### PR TITLE
Use multiqc default template when site is upps

### DIFF
--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -18,3 +18,6 @@ megaqc_url: http://megaqc.scilifelab.se/api/upload_parse
 megaqc_access_token: {{ megaqc_token_sthlm_stage }}
 {% endif %}
 {% endif %}
+{% if item.site == "upps" and deployment_environment in ["production", "staging"]%}
+template: default
+{% endif %}


### PR DESCRIPTION
The template used for multiqc-reports is changed from "ngi" to "default" if the specified site is upps.