### PR TITLE
Set MultiQC config.swedac_accredited according to NGI node

### DIFF
--- a/roles/multiqc/defaults/main.yml
+++ b/roles/multiqc/defaults/main.yml
@@ -4,4 +4,4 @@ multiqc_version: "v1.7"
 
 multiqc_ngi_repo: https://github.com/ewels/MultiQC_NGI.git
 multiqc_ngi_dest: "{{ sw_path }}/multiqc_ngi"
-multiqc_ngi_version: "v0.6"
+multiqc_ngi_version: "v0.6.2"

--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -1,11 +1,16 @@
 ---
 no_version_check: True
 
+{% if item.site == "upps" %}
+swedac_accredited: False
+{% endif %}
+
 {% if item.site == "sthlm" and deployment_environment in ["production", "staging"]%}
 push_statusdb: True
 save_remote: True
 template: ngi
 plots_flat_numseries: 1000
+swedac_accredited: True
 {% if deployment_environment == "production" %}
 remote_sshkey: "/home/funk_006/ssh_keys/id_rsa"
 remote_port: '5912'             # Optional

--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -3,6 +3,7 @@ no_version_check: True
 
 {% if item.site == "upps" %}
 swedac_accredited: False
+swedac_location: 'uppsala'
 {% endif %}
 
 {% if item.site == "sthlm" and deployment_environment in ["production", "staging"]%}
@@ -11,6 +12,7 @@ save_remote: True
 template: ngi
 plots_flat_numseries: 1000
 swedac_accredited: True
+swedac_location: 'stockholm'
 {% if deployment_environment == "production" %}
 remote_sshkey: "/home/funk_006/ssh_keys/id_rsa"
 remote_port: '5912'             # Optional


### PR DESCRIPTION
To tie in with https://github.com/ewels/MultiQC_NGI/commit/13daca016813eabd89dc81c376ebc7d13dae6d42 so that Uppsala does not have the Swedac ISO accreditation badge in the MultiQC report footer.