### PR TITLE
Use nextflow snapshot

### DIFF
--- a/roles/arteria-siswrap-ws/defaults/main.yml
+++ b/roles/arteria-siswrap-ws/defaults/main.yml
@@ -38,7 +38,7 @@ virtual_env_command: "/usr/bin/python /lupus/ngi/irma3/virtualenv-15.0.0/virtual
 
 sisyphus_path: "{{ arteria_siswrap_env_root }}/deps/sisyphus/"
 sisyphus_git_repo: https://github.com/Molmed/sisyphus.git
-sisyphus_repo_branch: master
+sisyphus_repo_branch: v16.2.0
 
 # Where to install our local Perl packages
 perllib_dest: "{{ ngi_resources }}/arteria/perl"

--- a/roles/multiqc/defaults/main.yml
+++ b/roles/multiqc/defaults/main.yml
@@ -4,4 +4,4 @@ multiqc_version: "v1.7"
 
 multiqc_ngi_repo: https://github.com/ewels/MultiQC_NGI.git
 multiqc_ngi_dest: "{{ sw_path }}/multiqc_ngi"
-multiqc_ngi_version: "v0.6.2"
+multiqc_ngi_version: "0.6.2"

--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -1,3 +1,3 @@
 nextflow_java: "/sw/comp/java/x86_64/sun_jdk1.8.0_151"
-nextflow_version_tag: "v19.01.0"
+nextflow_version_tag: "v19.03.0-edge"
 nextflow_download_url: "https://github.com/nextflow-io/nextflow/releases/download/{{ nextflow_version_tag }}/nextflow"


### PR DESCRIPTION
This PR will deploy the latest Nextflow release which should include a fix for slurm-issues. In addition, it specifies versions for MultiQC_NGI and Sisyphus.
