### PR TITLE
Modified Irma specific sarek config

### DIFF
--- a/roles/sarek/files/sarek_irma.config
+++ b/roles/sarek/files/sarek_irma.config
@@ -5,8 +5,8 @@ params.singleCPUMem = 15.GB
 params.max_memory = {params.totalMemory}
 process.memory = {params.totalMemory}
 
-/* Fix for processes remapped to node queue by uppmax
- * Can be removed when next version (>2.3.FIX1) is used
+// Fix for processes remapped to node queue by uppmax
+// Can be removed when next version (>2.3.FIX1) is used
 process {
   withName:ConcatVCF {
     queue = 'node'

--- a/roles/sarek/files/sarek_irma.config
+++ b/roles/sarek/files/sarek_irma.config
@@ -4,3 +4,16 @@ params.totalMemory = 250.GB
 params.singleCPUMem = 15.GB
 params.max_memory = {params.totalMemory}
 process.memory = {params.totalMemory}
+
+/* Fix for processes remapped to node queue by uppmax
+ * Can be removed when next version (>2.3.FIX1) is used
+process {
+  withName:ConcatVCF {
+    queue = 'node'
+  }
+  withName:MergeBams {
+    memory = {params.singleCPUMem * task.attempt}
+    time = {params.runTime * task.attempt}
+    queue = 'node'
+  }
+}


### PR DESCRIPTION
Updated config file to make sure that processes using a full node is also submitted to the node queue. Remapping of these jobs by uppmax are causing errors where Nextflow loose track of the job in the slurm queue. 