### PR TITLE
Added fix for Sarek wasteful resource usage due to wrong queue

### DIFF
--- a/roles/sarek/files/sarek_irma.config
+++ b/roles/sarek/files/sarek_irma.config
@@ -7,6 +7,8 @@ process.memory = {params.totalMemory}
 
 // Fix for processes remapped to node queue by uppmax
 // Can be removed when next version (>2.3.FIX1) is used
+// and processes specifying less than max nr cpus but
+// without using the 'core' queue
 process {
   withName:ConcatVCF {
     queue = 'node'
@@ -15,5 +17,29 @@ process {
     memory = {params.singleCPUMem * task.attempt}
     time = {params.runTime * task.attempt}
     queue = 'node'
+  }
+  withName:RunBcftoolsStats {
+    cpus = 1
+    queue = 'core'
+  }
+  withName:RunFastQC {
+    cpus = 2 // FastQC is only capable of running one thread per fastq file.
+    errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
+    queue = 'core'
+  }
+  withName:RunGenotypeGVCFs {
+    cpus = 1
+    memory = {params.singleCPUMem}
+    queue = 'core'
+  }
+  withName:RunMultiQC {
+    errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
+    cpus = 1
+    queue = 'core'
+  }
+  withName:RunSamtoolsStats {
+    cpus = 1
+    time = {params.runTime * task.attempt}
+    queue = 'core'
   }
 }

--- a/roles/sarek/files/sarek_irma.config
+++ b/roles/sarek/files/sarek_irma.config
@@ -20,11 +20,13 @@ process {
   withName:RunBcftoolsStats {
     cpus = 1
     queue = 'core'
+    memory = {params.singleCPUMem}
   }
   withName:RunFastQC {
     cpus = 2 // FastQC is only capable of running one thread per fastq file.
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
     queue = 'core'
+    memory = {2*params.singleCPUMem}
   }
   withName:RunGenotypeGVCFs {
     cpus = 1
@@ -35,10 +37,12 @@ process {
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
     cpus = 1
     queue = 'core'
+    memory = {params.singleCPUMem}
   }
   withName:RunSamtoolsStats {
     cpus = 1
     time = {params.runTime * task.attempt}
     queue = 'core'
+    memory = {params.singleCPUMem}
   }
 }

--- a/roles/sarek/files/sarek_irma.config
+++ b/roles/sarek/files/sarek_irma.config
@@ -14,7 +14,6 @@ process {
     queue = 'node'
   }
   withName:MergeBams {
-    memory = {params.singleCPUMem * task.attempt}
     time = {params.runTime * task.attempt}
     queue = 'node'
   }


### PR DESCRIPTION
I'll make these changes to Sarek repo as well, but I think it's faster to get it in production this way.