### PR TITLE
Format .config files with Nextflow syntax highlighting on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.config linguist-language=nextflow


### PR DESCRIPTION
Assuming that all `.config` files in this repo are for Nextflow, this file will force GitHub to use Nextflow syntax highlighting. Minor thing, but helps spot syntax errors :)