### PR TITLE
Bump multiqc_ngi version

### DIFF
--- a/roles/multiqc/defaults/main.yml
+++ b/roles/multiqc/defaults/main.yml
@@ -4,4 +4,4 @@ multiqc_version: "v1.7"
 
 multiqc_ngi_repo: https://github.com/NationalGenomicsInfrastructure/MultiQC_NGI.git
 multiqc_ngi_dest: "{{ sw_path }}/multiqc_ngi"
-multiqc_ngi_version: "0.6.2"
+multiqc_ngi_version: "0.6.3"


### PR DESCRIPTION
The new version solves the issue of the yaml load warning display. 