### PR TITLE
Updated ngi-pipeline to fix yaml.load warning

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -19,7 +19,7 @@ bash_env_sthlm_script: sourceme_sthlm.sh
 
 ngi_pipeline_repo: https://github.com/NationalGenomicsInfrastructure/ngi_pipeline.git
 ngi_pipeline_dest: "{{ sw_path }}/ngi_pipeline"
-ngi_pipeline_version: 2f9af8a8938dafc5d724c48ce9d8a77524ef2556
+ngi_pipeline_version: 036f989ef200369378eadf3b38e913f89f80ede5
 NGI_venv_name: "NGI"
 ngi_pipeline_venv: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_name }}"
 


### PR DESCRIPTION
We want to update the latest stage deployment with this so that the yam.load warning does not show up any more.