### PR TITLE
Irma nextflow config

### DIFF
--- a/roles/nextflow/tasks/main.yml
+++ b/roles/nextflow/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Create NextFlow installation subdirectory
   file: path="{{ nextflow_dest }}/workfiles" state=directory mode=g+rwXs
 
-- name: Download NextFlow 
+- name: Download NextFlow
   get_url: url="{{ nextflow_download_url }}" dest="{{ nextflow_dest }}/nextflow" mode="u+rwx,g=rwx"
 
 # Resolved any problems. Run-time files are pushed to scratch
@@ -32,6 +32,14 @@
               line="export PATH={{ root_path }}/sw/nextflow:$PATH"
               backup=no
 ###
+
+- name: Create irma config
+  template:
+    src: "nextflow_irma_site.config"
+    dest: "{{ ngi_pipeline_conf }}/nextflow_irma_{{ item.site }}.config"
+  with_items:
+  - { site: "sthlm", project_id: "{{ ngi_pipeline_sthlm_delivery }}" }
+  - { site: "upps", project_id: "{{ ngi_pipeline_upps_delivery }}" }
 
 # Change target to {{ ngi_rnaseq_dest }} when using module system
 # NXF_WORK is omitted, which puts them under current directory

--- a/roles/nextflow/templates/nextflow_irma_site.config
+++ b/roles/nextflow/templates/nextflow_irma_site.config
@@ -1,0 +1,27 @@
+params {
+    config_profile_description = 'Swedish UPPMAX cluster profile specifically for the Irma cluster'
+    config_profile_contact = 'National Genomics Infrastructure (support@ngisweden.se)'
+    config_profile_url = 'https://www.uppmax.uu.se/'
+
+    project = "{{ item.project_id }}"
+
+    multiqc_config = "{{ ngi_pipeline_conf }}/multiqc_{{ item.site }}_config.yml"
+    max_memory = 250.GB
+    max_cpus = 16
+    max_time = 240.h
+    // illumina iGenomes reference file paths on UPPMAX
+    igenomes_base = '/sw/data/uppnex/igenomes/'
+}
+
+process {
+    executor = 'slurm'
+    clusterOptions = { "-A $params.project ${params.clusterOptions ?: ''}" }
+    withName:multiqc {
+        container = null
+        executor = 'local'
+    }
+}
+
+singularity {
+    enabled = true
+}

--- a/roles/rnaseq/tasks/main.yml
+++ b/roles/rnaseq/tasks/main.yml
@@ -38,7 +38,8 @@
   lineinfile:
     dest: "{{ ngi_pipeline_conf }}/{{ item.script }}"
     line: >
-          alias rnaseq='nextflow run {{ rnaseq_dest }}/main.nf -profile uppmax
+          alias rnaseq='nextflow run {{ rnaseq_dest }}/main.nf
+          -c {{ ngi_pipeline_conf }}/nextflow_irma_{{ item.site }}.config
           -c {{ ngi_pipeline_conf }}/rnaseq_{{ item.site }}.config'
     backup: no
   with_items:

--- a/roles/rnaseq/templates/rnaseq_site.config
+++ b/roles/rnaseq/templates/rnaseq_site.config
@@ -1,12 +1,6 @@
 process {
     container = '{{ rnaseq_container_path }}/{{ rnaseq_image }}'
-    withName:multiqc {
-        container = null
-        executor = 'local'
-    }
 }
 params {
     reverse_stranded = true
-    project = "{{ item.project_id }}"
-    multiqc_config = "{{ ngi_pipeline_conf }}/multiqc_{{ item.site }}_config.yml"
 }


### PR DESCRIPTION
My take on what I think @ewels was saying today (please correct me if I misunderstood something).

This would remove the need for `-profile uppmax` and instead replace it with a general irma nextflow config file. The long term goal is to use `nf-core download` inside of the playbook to remove a lot of code. 