### PR TITLE
Needed backslashes for newlines

### DIFF
--- a/roles/methylseq/tasks/main.yml
+++ b/roles/methylseq/tasks/main.yml
@@ -42,8 +42,8 @@
   lineinfile:
       dest: "{{ ngi_pipeline_conf }}/{{ item.script }}"
       line: >
-        alias methylseq='nextflow run {{ methylseq_dest }}/
-             -c {{ ngi_pipeline_conf }}/nextflow_irma_{{ item.site }}.config
+        alias methylseq='nextflow run {{ methylseq_dest }}/ \
+             -c {{ ngi_pipeline_conf }}/nextflow_irma_{{ item.site }}.config \
              -c {{ ngi_pipeline_conf }}/methylseq_{{ item.site }}.config'
       backup: no
   with_items:

--- a/roles/rnaseq/tasks/main.yml
+++ b/roles/rnaseq/tasks/main.yml
@@ -38,8 +38,8 @@
   lineinfile:
     dest: "{{ ngi_pipeline_conf }}/{{ item.script }}"
     line: >
-          alias rnaseq='nextflow run {{ rnaseq_dest }}/
-              -c {{ ngi_pipeline_conf }}/nextflow_irma_{{ item.site }}.config
+          alias rnaseq='nextflow run {{ rnaseq_dest }}/ \
+              -c {{ ngi_pipeline_conf }}/nextflow_irma_{{ item.site }}.config \
               -c {{ ngi_pipeline_conf }}/rnaseq_{{ item.site }}.config'
     backup: no
   with_items:


### PR DESCRIPTION
Bugfix for the aliases of methylseq and rnaseq.