### PR TITLE
Add MegaQC details to upps multiqc config

### DIFF
--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -5,6 +5,10 @@ export_plots: true
 {% if item.site == "upps" %}
 swedac_accredited: False
 swedac_location: 'uppsala'
+{% if deployment_environment == "production" %}
+megaqc_url: https://megaqc.snpseq.medsci.uu.se:443/api/upload_data
+megaqc_access_token: {{ megaqc_token_upps }}
+{% endif %}
 {% endif %}
 
 {% if item.site == "sthlm" and deployment_environment in ["production", "staging"]%}


### PR DESCRIPTION
Add MegaQC details to upps multiqc config. The access token has been added to `megaqc_token.yaml`  on irma3. 