### PR TITLE
Write site specific resources to separate folders

### DIFF
--- a/roles/sarek/tasks/main.yml
+++ b/roles/sarek/tasks/main.yml
@@ -56,7 +56,7 @@
 - name: Create Delivery READMEs and add to TACA resources
   template:
     src: "DELIVERY.README.SAREK.txt.j2"
-    dest: "{{ ngi_resources }}/TACA/{{ item.site }}.DELIVERY.README.SAREK.txt"
+    dest: "{{ ngi_resources }}/TACA/{{ item.site }}/DELIVERY.README.SAREK.txt"
   with_items:
     - site: sthlm
     - site: upps

--- a/roles/taca/tasks/main.yml
+++ b/roles/taca/tasks/main.yml
@@ -17,8 +17,14 @@
 - name: Create TACA delivery configs directory
   file: path="{{ ngi_pipeline_conf }}/TACA" state=directory mode=g+s
 
-- name: Create TACA resources folder
-  file: path="{{ ngi_resources }}/TACA" state=directory mode=g+s
+- name: Create TACA resources folders for each site
+  file: 
+    path: "{{ ngi_resources }}/TACA/{{ item }}"
+    state: directory
+    mode: g+s
+  with_items:
+    - "upps"
+    - "sthlm"
 
 - set_fact:
     site: "upps"

--- a/roles/taca/templates/site_taca_sarek_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_delivery.yml.j2
@@ -61,8 +61,8 @@ deliver:
             - <STAGINGPATH>/<SAMPLEID>/results/VariantCalling/
             - required: True
         -
-            - {{ ngi_resources }}/TACA/{{ site }}.DELIVERY.README.SAREK.txt
-            - <STAGINGPATH>/DELIVERY.README.SAREK.txt
+            - {{ ngi_resources }}/TACA/{{ site }}/DELIVERY.README.SAREK.txt
+            - <STAGINGPATH>
             - required: True
         -
             - {{ ngi_resources }}/TACA/apply_recalibration.sh


### PR DESCRIPTION
During testing, it was discovered that the delivery README was incorrectly staged for sarek data. 

I thought 
```
            - {{ ngi_resources }}/TACA/{{ site }}.DELIVERY.README.SAREK.txt
            - <STAGINGPATH>/DELIVERY.README.SAREK.txt
```
would stage `{{ site }}.DELIVERY.README.SAREK.txt` as `DELIVERY.README.SAREK.txt`, but instead TACA makes a folder called `DELIVERY.README.SAREK.txt` and puts the README there, e.g :
```
staging_path
  |__ DELIVERY.README.SAREK.txt
       |__ upps.DELIVERY.README.SAREK.txt
```

To tackle this problem, the delivery configs are now written without prefixes and are put in separate folders. 