### PR TITLE
Make playbooks and roles compatible with Ansible 2.9

### DIFF
--- a/roles/archive-upload-ws/tasks/1_install.yml
+++ b/roles/archive-upload-ws/tasks/1_install.yml
@@ -13,7 +13,6 @@
       virtualenv: "{{ archive_upload_env_root }}"
       virtualenv_command: "{{ archive_upload_virtual_env_command }}"
       state: present
-      executable: "{{ archive_upload_env_root }}/bin/pip"
       extra_args: "-U"
 
 - name: install archive-upload
@@ -23,6 +22,5 @@
       virtualenv: "{{ archive_upload_env_root }}"
       virtualenv_command: "{{ archive_upload_virtual_env_command }} "
       state: present
-      executable: "{{ archive_upload_env_root }}/bin/pip"
       extra_args: "-U"
 

--- a/roles/arteria-checksum-ws/tasks/1_install.yml
+++ b/roles/arteria-checksum-ws/tasks/1_install.yml
@@ -13,7 +13,6 @@
       virtualenv: "{{ arteria_checksum_env_root }}"
       virtualenv_command: "{{ arteria_checksum_virtual_env_command }}"
       state: present
-      executable: "{{ arteria_checksum_env_root }}/bin/pip"
       extra_args: "-U"
 
 - name: install arteria-checksum
@@ -23,6 +22,5 @@
       virtualenv: "{{ arteria_checksum_env_root }}"
       virtualenv_command: "{{ arteria_checksum_virtual_env_command }}"
       state: present
-      executable: "{{ arteria_checksum_env_root }}/bin/pip"
       extra_args: "-U"
 

--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port. 
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v2.4.0
+arteria_delivery_version: v2.4.1
 
 arteria_install_path: "{{ sw_path }}/arteria"
 conda_bin: "{{ sw_path }}/anaconda/bin/conda"

--- a/roles/multiqc/tasks/main.yml
+++ b/roles/multiqc/tasks/main.yml
@@ -14,9 +14,9 @@
     executable: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_py3_name }}/bin/pip"
 
 - name: Install MultiQC
-  shell: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_py3_name }}/bin/pip install ."
-  args:
-    chdir: "{{ multiqc_dest }}"
+  pip:
+    name: "file:{{ multiqc_dest }}"
+    virtualenv: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_py3_name }}"
 
 - name: Fetch MultiQC NGI plugin from GitHub
   git: repo="{{ multiqc_ngi_repo }}"
@@ -27,9 +27,9 @@
 #Remember to use --upgrade flag if using commit-id
 #Using the python3 env
 - name: Install MultiQC NGI submodule
-  shell: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_py3_name }}/bin/pip install ."
-  args:
-    chdir: "{{ multiqc_ngi_dest }}"
+  pip:
+    name: "file:{{ multiqc_ngi_dest }}"
+    virtualenv: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_py3_name }}"
 
 - name: Deploy multiqc configs
   template: src="multiqc_config.yml.j2" dest="{{ ngi_pipeline_conf }}/multiqc_{{ item.site }}_config.yml"

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -7,7 +7,7 @@
        force=yes
 
 - name: "Check if {{ NGI_venv_name }} virtual env exists"
-  shell: "conda env list | awk '{print $1}' | egrep -e ^{{ NGI_venv_name }}$"
+  shell: "conda env list | awk '{print $1}' | egrep -e ^{{ NGI_venv_name }}$"
   register: "py2_venv_exists"
   ignore_errors: true
 
@@ -16,7 +16,7 @@
   when: "not py2_venv_exists.stdout"
 
 - name: "Check if {{ NGI_venv_py3_name }} virtual env exists"
-  shell: "conda env list | awk '{print $1}' | egrep -e ^{{ NGI_venv_py3_name }}$"
+  shell: "conda env list | awk '{print $1}' | egrep -e ^{{ NGI_venv_py3_name }}$"
   register: "py3_venv_exists"
   ignore_errors: true
 

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -137,7 +137,7 @@
   lineinfile:
     dest: "{{ deployed_tool_versions }}"
     line: "Anaconda: {{ conda_version.stderr }}"
-  when: "'{{ conda_version.stderr }}'" #for some reason saved as stderr
+  when: conda_version.stderr #for some reason saved as stderr
 
 - name: Store ngi_pipeline version in deployment
   lineinfile:

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -25,13 +25,20 @@
   when: "not py3_venv_exists.stdout"
 
 - name: (Temporary until everything is updated) Install click7.0 as click7.1 breaks everything
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install click==7.0"
+  pip:
+    name: click
+    version: "7.0"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Install ngi_pipeline requirements
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install -r {{ ngi_pipeline_dest }}/requirements.txt"
+  pip:
+    requirements: "{{ ngi_pipeline_dest }}/requirements.txt"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Install ngi_pipeline
-  shell: "cd {{ ngi_pipeline_dest }} && {{ ngi_pipeline_venv }}/bin/pip install ."
+  pip:
+    name: "file:{{ ngi_pipeline_dest }}"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Create ngi_pipeline conf directory
   file: path="{{ ngi_pipeline_conf }}" state=directory mode=g+s
@@ -46,7 +53,9 @@
   when: deployment_environment in ["staging", "devel"]
 
 - name: Install PyVCF for joint calling
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install PyVCF"
+  pip:
+    name: "PyVCF"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Create ngi_resources folder
   file: name="{{ ngi_resources }}" state=directory mode=g+s

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -8,21 +8,21 @@
 
 - name: "Check if {{ NGI_venv_name }} virtual env exists"
   shell: "conda env list | awk '{print $1}' | egrep -e ^{{ NGI_venv_name }}$"
-  register: "{{ NGI_venv_name }}_venv_exists"
+  register: "py2_venv_exists"
   ignore_errors: true
 
 - name: Setup virtual env and install dependencies
   shell: "conda create -n {{ NGI_venv_name }} pip"
-  when: "not {{ NGI_venv_name }}_venv_exists.stdout"
+  when: "not py2_venv_exists.stdout"
 
 - name: "Check if {{ NGI_venv_py3_name }} virtual env exists"
   shell: "conda env list | awk '{print $1}' | egrep -e ^{{ NGI_venv_py3_name }}$"
-  register: "{{ NGI_venv_py3_name }}_venv_exists"
+  register: "py3_venv_exists"
   ignore_errors: true
 
 - name: Setup virtual env with python3 and install dependencies
   shell: "conda create -n {{ NGI_venv_py3_name }} -c anaconda python=3.8"
-  when: "not {{ NGI_venv_py3_name }}_venv_exists.stdout"
+  when: "not py3_venv_exists.stdout"
 
 - name: (Temporary until everything is updated) Install click7.0 as click7.1 breaks everything
   shell: "{{ ngi_pipeline_venv }}/bin/pip install click==7.0"

--- a/roles/ngi_reports/tasks/dependencies.yml
+++ b/roles/ngi_reports/tasks/dependencies.yml
@@ -6,12 +6,16 @@
        force=yes
 
 - name: Install ngi_visualizations requirements
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install -r {{ ngi_visual_dest }}/requirements.txt"
+  pip:
+    requirements: "{{ ngi_visual_dest }}/requirements.txt"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Install ngi_visualizations
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install ."
-  args:
-    chdir: "{{ ngi_visual_dest }}"
+  pip:
+    name: "file:{{ ngi_visual_dest }}"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Install couchDB (minimal version of statusDB)
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install couchdb"
+  pip:
+    name: "couchdb"
+    virtualenv: "{{ ngi_pipeline_venv }}"

--- a/roles/ngi_reports/tasks/main.yml
+++ b/roles/ngi_reports/tasks/main.yml
@@ -9,10 +9,9 @@
        recursive=yes
 
 - name: Install ngi_reports
-  shell: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_py3_name }}/bin/pip install -e ."
-  args:
-    chdir: "{{ ngi_reports_dest }}"
-
+  pip:
+    name: "file:{{ ngi_reports_dest }}"
+    virtualenv: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_py3_name }}"
 
 - name: Create ngi_reports conf file
   template: src="ngi_reports_sthlm.conf.j2" dest="{{ ngi_pipeline_conf }}/ngi_reports_sthlm.conf"

--- a/roles/ngi_reports/tasks/main.yml
+++ b/roles/ngi_reports/tasks/main.yml
@@ -12,6 +12,7 @@
   pip:
     name: "file:{{ ngi_reports_dest }}"
     virtualenv: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_py3_name }}"
+    editable: yes
 
 - name: Create ngi_reports conf file
   template: src="ngi_reports_sthlm.conf.j2" dest="{{ ngi_pipeline_conf }}/ngi_reports_sthlm.conf"

--- a/roles/taca/tasks/dependencies.yml
+++ b/roles/taca/tasks/dependencies.yml
@@ -23,12 +23,14 @@
        force=yes
 
 - name: Install statusdb requirements
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install -r {{ statusdb_dest }}/requirements.txt"
+  pip:
+    requirements: "{{ statusdb_dest }}/requirements.txt"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Install statusDB
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install ."
-  args:
-    chdir: "{{ statusdb_dest }}"
+  pip:
+    name: "file:{{ statusdb_dest }}"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Copy statusDB credentials
   copy: src="files/{{ statusdb_creds }}" dest="{{ ngi_pipeline_conf }}/{{ statusdb_creds }}"
@@ -45,12 +47,14 @@
        force=yes
 
 - name: Install flowcell_parser requirements
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install -r {{ flowcell_parser_dest }}/requirements.txt"
+  pip:
+    requirements: "{{ flowcell_parser_dest }}/requirements.txt"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Install flowcell_parser
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install ."
-  args:
-    chdir: "{{ flowcell_parser_dest }}"
+  pip:
+    name: "file:{{ flowcell_parser_dest }}"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Fetch TACA from GitHub
   git: repo="{{ taca_repo }}"
@@ -59,9 +63,11 @@
        force=yes
 
 - name: Install TACA requirements
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install -r {{ taca_dest }}/requirements.txt"
+  pip:
+    requirements: "{{ taca_dest }}/requirements.txt"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Install TACA
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install ."
-  args:
-    chdir: "{{ taca_dest }}"
+  pip:
+    name: "file:{{ taca_dest }}"
+    virtualenv: "{{ ngi_pipeline_venv }}"

--- a/roles/taca/tasks/main.yml
+++ b/roles/taca/tasks/main.yml
@@ -7,12 +7,14 @@
        force=yes
 
 - name: Install TACA-ngi-pipeline requirements
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install -r {{ taca_ngi_dest }}/requirements.txt"
+  pip:
+    requirements: "{{ taca_ngi_dest }}/requirements.txt"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Install TACA-ngi-pipeline
-  shell: "{{ ngi_pipeline_venv }}/bin/pip install ."
-  args:
-    chdir: "{{ taca_ngi_dest }}"
+  pip:
+    name: "file:{{ taca_ngi_dest }}"
+    virtualenv: "{{ ngi_pipeline_venv }}"
 
 - name: Create TACA delivery configs directory
   file: path="{{ ngi_pipeline_conf }}/TACA" state=directory mode=g+s

--- a/roles/taca/templates/site_taca_cleanup.yml.j2
+++ b/roles/taca/templates/site_taca_cleanup.yml.j2
@@ -1,5 +1,5 @@
 log:
-    log_file: "{{ ngi_pipeline_site_path }}/taca.log"
+    log_file: "{{ ngi_pipeline_site_path }}/taca.log"
 
 cleanup:
     irma:

--- a/roles/ugc/tasks/main.yml
+++ b/roles/ugc/tasks/main.yml
@@ -36,4 +36,4 @@
   lineinfile:
     dest: "{{ deployed_tool_versions }}"
     line: "ugc-delivery: {{ delivery_version.stdout }}"
-  when: "'{{ delivery_version.stdout }}'"
+  when: delivery_version.stdout

--- a/tasks/post-install.yml
+++ b/tasks/post-install.yml
@@ -9,7 +9,7 @@
       lineinfile:
         dest: "{{ deployed_tool_versions }}"
         line: "-- Deployed at {{ ansible_date_time.iso8601 }} by irma_provision ({{ irma_provision_version.stdout }}) --"
-      when: "'{{ irma_provision_version.stdout }}'"
+      when: irma_provision_version.stdout
 
     # Create an alias to easily get the deployed tools version
     # not using 'blockinline' to avoid ansible markers


### PR DESCRIPTION
This PR makes our roles and playbooks compatible with Ansible 2.9.
While I was at it, I also made some style changes and replaced all invocations of `pip` via shell with the ansible `pip` module.

On irma I installed ansible-2.9 besides our current (2.0) installation and symlinked `/lupus/ngi/irma3/ansible-env` to the ansible-2.0 installation. Once we merge this PR, we need to change that symlink to point to the 2.9 installation instead.