### PR TITLE
Update to rnaseq3 with new temp role, bump nextflow to v20.10.0

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -41,6 +41,7 @@
     - { role: misc-tools, tags: misc-tools }
     - { role: archive-upload-ws, tags: archive-upload }
     - { role: nf-core, tags: nf-core }
+    - { role: nf-core-biocontainer-temp, tags: nf-core-biocontainer-temp }
     - { role: sarek, tags: sarek }
 
   environment: "{{ anaconda_env }}"

--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -1,3 +1,3 @@
 nextflow_java: "/sw/comp/java/x86_64/sun_jdk1.8.0_151"
-nextflow_version_tag: "v20.01.0"
+nextflow_version_tag: "v20.10.0"
 nextflow_download_url: "https://github.com/nextflow-io/nextflow/releases/download/{{ nextflow_version_tag }}/nextflow"

--- a/roles/nf-core-biocontainer-temp/defaults/main.yml
+++ b/roles/nf-core-biocontainer-temp/defaults/main.yml
@@ -1,0 +1,3 @@
+pipelines:
+  - name: rnaseq
+    release: 3.0

--- a/roles/nf-core-biocontainer-temp/tasks/main.yml
+++ b/roles/nf-core-biocontainer-temp/tasks/main.yml
@@ -16,12 +16,14 @@
 
 - name: Create temp directories for download
   file:
-    path: "{{ ngi_containers }}/download"
+    path: "{{ item }}"
     state: directory
+  with_items:
+    - "{{ ngi_containers }}/download"
+    - "{{ ngi_containers }}/download/biocontainers"
 
 #Download these for rnaseq 3 containers until nf-core dowload is updated
 #wget -L https://dl.dropboxusercontent.com/s/5venz3l2wihaqdp/nf-core-rnaseq_v3.0.tar.gz
-#wget -L https://dl.dropboxusercontent.com/s/0w2e72pz2iuj37e/nf-core-rnaseq_v3.0.tar.gz.md5
 
 - name: Download containers
   get_url:
@@ -32,14 +34,21 @@
 - name: Unarchive downloaded file
   unarchive:
     src: "{{ ngi_containers }}/download/nf-core-rnaseq_v3.0.tar.gz"
-    dest: "{{ ngi_containers }}/biocontainers"
+    dest: "{{ ngi_containers }}/download/biocontainers"
     remote_src: yes
+
+- name: Move unarchived files to biocontainers
+  synchronize:
+    src: "{{ ngi_containers }}/download/biocontainers/nf-core-rnaseq_v3.0/"
+    dest: "{{ ngi_containers }}/biocontainers/"
+
 
 - name: Clean download
   file:
     path: "{{ item }}"
     state: absent
   with_items:
+    - "{{ ngi_containers }}/download/biocontainers/"
     - "{{ ngi_containers }}/download/nf-core-rnaseq_v3.0.tar.gz"
     - "{{ ngi_containers }}/download"
 

--- a/roles/nf-core-biocontainer-temp/tasks/main.yml
+++ b/roles/nf-core-biocontainer-temp/tasks/main.yml
@@ -16,11 +16,8 @@
 
 - name: Create temp directories for download
   file:
-    path: "{{ item }}"
+    path: "{{ ngi_containers }}/download/biocontainers"
     state: directory
-  with_items:
-    - "{{ ngi_containers }}/download"
-    - "{{ ngi_containers }}/download/biocontainers"
 
 #Download these for rnaseq 3 containers until nf-core dowload is updated
 #wget -L https://dl.dropboxusercontent.com/s/5venz3l2wihaqdp/nf-core-rnaseq_v3.0.tar.gz
@@ -41,7 +38,6 @@
   synchronize:
     src: "{{ ngi_containers }}/download/biocontainers/nf-core-rnaseq_v3.0/"
     dest: "{{ ngi_containers }}/biocontainers/"
-
 
 - name: Clean download
   file:

--- a/roles/nf-core-biocontainer-temp/tasks/main.yml
+++ b/roles/nf-core-biocontainer-temp/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+- name: install nf-core/rnaseq
+  command: "{{ nf_core_env }}/bin/nf-core -v download {{ item.name }}
+   --compress none --outdir {{ sw_path }}{{ item.name }} --release {{ item.release }}"
+  environment:
+    PATH: "{{ nf_core_env }}/bin:{{ ansible_env.PATH }}"
+  args:
+    chdir: "{{ sw_path }}"
+  with_items: "{{ pipelines }}"
+
+- name: Create directory for rnaseq biocontainers
+  file:
+    path: "{{ ngi_containers }}/biocontainers"
+    state: directory
+    mode: 02775 #ug=rwx, o=rx, g+s
+
+- name: Create temp directories for download
+  file:
+    path: "{{ ngi_containers }}/download"
+    state: directory
+
+#Download these for rnaseq 3 containers until nf-core dowload is updated
+#wget -L https://dl.dropboxusercontent.com/s/5venz3l2wihaqdp/nf-core-rnaseq_v3.0.tar.gz
+#wget -L https://dl.dropboxusercontent.com/s/0w2e72pz2iuj37e/nf-core-rnaseq_v3.0.tar.gz.md5
+
+- name: Download containers
+  get_url:
+    url: https://dl.dropboxusercontent.com/s/5venz3l2wihaqdp/nf-core-rnaseq_v3.0.tar.gz
+    dest: "{{ ngi_containers }}/download/nf-core-rnaseq_v3.0.tar.gz"
+    remote_src: yes
+
+- name: Unarchive downloaded file
+  unarchive:
+    src: "{{ ngi_containers }}/download/nf-core-rnaseq_v3.0.tar.gz"
+    dest: "{{ ngi_containers }}/biocontainers"
+    remote_src: yes
+
+- name: Clean download
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ ngi_containers }}/download/nf-core-rnaseq_v3.0.tar.gz"
+    - "{{ ngi_containers }}/download"
+
+- name: Create nf-core config
+  template:
+    src: "site.config.j2"
+    dest: "{{ ngi_pipeline_conf }}/{{ item.0.name }}_{{ item.1.site }}.config"
+  with_nested:
+  - "{{ pipelines }}"
+  - [ { site: "sthlm", project_id: "{{ ngi_pipeline_sthlm_delivery }}" }, { site: "upps", project_id: "{{ ngi_pipeline_upps_delivery }}" }]
+
+- name: Set alias for pipeline
+  lineinfile:
+    dest: "{{ ngi_pipeline_conf }}/{{ item.1.script }}"
+    line: >
+          alias {{ item.0.name }}='nextflow run {{ sw_path }}{{ item.0.name }}/workflow/ \
+          -profile uppmax \
+          -c {{ ngi_pipeline_conf }}/nextflow_irma_{{ item.1.site }}.config \
+          -c {{ ngi_pipeline_conf }}/{{ item.0.name }}_{{ item.1.site }}.config'
+    backup: no
+  with_nested:
+  - "{{ pipelines }}"
+  - [ { site: "sthlm", script: "{{ bash_env_sthlm_script }}" }, { site: "upps", script: "{{ bash_env_upps_script }}" } ]
+
+- name: Store tool version in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "{{ item.name }}: {{ item.release }}"
+  with_items:
+  - "{{ pipelines }}"

--- a/roles/nf-core-biocontainer-temp/templates/site.config.j2
+++ b/roles/nf-core-biocontainer-temp/templates/site.config.j2
@@ -1,6 +1,4 @@
 {% if item.0.name=='rnaseq' %}
 params.reverseStranded = true
-{% endif %}
-{% if item.0.name=='rnaseq' %}
 params.seq_center = "SciLifeLab National Genomics Infrastructure Stockholm"
 {% endif %}

--- a/roles/nf-core-biocontainer-temp/templates/site.config.j2
+++ b/roles/nf-core-biocontainer-temp/templates/site.config.j2
@@ -1,0 +1,6 @@
+{% if item.0.name=='rnaseq' %}
+params.reverseStranded = true
+{% endif %}
+{% if item.0.name=='rnaseq' %}
+params.seq_center = "SciLifeLab National Genomics Infrastructure Stockholm"
+{% endif %}

--- a/roles/nf-core-biocontainer-temp/templates/site.config.j2
+++ b/roles/nf-core-biocontainer-temp/templates/site.config.j2
@@ -1,4 +1,4 @@
 {% if item.0.name=='rnaseq' %}
 params.reverseStranded = true
-params.seq_center = "SciLifeLab National Genomics Infrastructure Stockholm"
 {% endif %}
+params.seq_center = "SciLifeLab National Genomics Infrastructure {% if item.1.site=='sthlm' %}Stockholm{% else %}Uppsala{% endif %}"

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -3,8 +3,6 @@ nextflow_version_tag: "v20.01.0"
 nextflow_download_url: "https://github.com/nextflow-io/nextflow/releases/download/{{ nextflow_version_tag }}/nextflow"
 nf_core_env: "/lupus/ngi/irma3/nf-core-env"
 pipelines:
-  - name: rnaseq
-    release: 1.4.2
   - name: methylseq
     release: 1.5
   - name: ampliseq

--- a/roles/ngi_pipeline/templates/sourceme_common.sh.j2
+++ b/roles/ngi_pipeline/templates/sourceme_common.sh.j2
@@ -7,13 +7,13 @@ export CHARON_BASE_URL={{ charon_base_url }}
 # Hopefully possible to remove dependency in a later version
 module load bioinfo-tools piper/{{ piper_module_version }}
 
-# Force English locale as e.g. some downstream scripts depend on the 
-# pipeline outputing data with "." as decimal output instead of Swedish ",". 
+# Force English locale as e.g. some downstream scripts depend on the
+# pipeline outputing data with "." as decimal output instead of Swedish ",".
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 
 # Append the Bash prompt with the version of the Irma environment/provisioning
-# that we're running. 
+# that we're running.
 IRMA_ENV=`echo $BASH_SOURCE | cut -d/ -f4`
 IRMA_VER=`echo $BASH_SOURCE | cut -d/ -f5`
 
@@ -27,3 +27,5 @@ export PS1="$IRMA_PROMPT [\u@\h \w]$ "
 
 # Default SNIC_TMP as /scratch
 export SNIC_TMP="/scratch"
+
+export NXF_SINGULARITY_CACHEDIR="{{ ngi_containers }}/biocontainers/nf-core-rnaseq_v3.0/"

--- a/roles/ngi_pipeline/templates/sourceme_common.sh.j2
+++ b/roles/ngi_pipeline/templates/sourceme_common.sh.j2
@@ -28,4 +28,4 @@ export PS1="$IRMA_PROMPT [\u@\h \w]$ "
 # Default SNIC_TMP as /scratch
 export SNIC_TMP="/scratch"
 
-export NXF_SINGULARITY_CACHEDIR="{{ ngi_containers }}/biocontainers/nf-core-rnaseq_v3.0/"
+export NXF_SINGULARITY_CACHEDIR="{{ ngi_containers }}/biocontainers/"


### PR DESCRIPTION
- Created a new temporary role to install rnaseq v3 until `nf-core download` is updated to handle biocontainers. 
- rnaseqv3 also requires nextflow v20.10.0.