### PR TITLE
Update nextflow release to get rnaseq to work

### DIFF
--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -1,3 +1,3 @@
 nextflow_java: "/sw/comp/java/x86_64/sun_jdk1.8.0_151"
-nextflow_version_tag: "v20.10.0"
+nextflow_version_tag: "20.11.0-edge"
 nextflow_download_url: "https://github.com/nextflow-io/nextflow/releases/download/{{ nextflow_version_tag }}/nextflow"


### PR DESCRIPTION
Phil said we need this nextflow version to get rnaseq v3.0 to work properly.