### PR TITLE
Bimonthly: fix arteria services

### DIFF
--- a/roles/archive-upload-ws/defaults/main.yml
+++ b/roles/archive-upload-ws/defaults/main.yml
@@ -17,7 +17,7 @@ archive_upload_monitored_path_stage: "/proj/{{ ngi_pipeline_upps_delivery }}/nob
 archive_upload_path_to_archive_root_prod: "/proj/{{ ngi_pipeline_upps_delivery }}/nobackup/arteria/pdc_archive_links/production/"
 archive_upload_path_to_archive_root_stage: "/proj/{{ ngi_pipeline_upps_delivery }}/nobackup/arteria/pdc_archive_links/staging/"
 
-archive_upload_env_root: "{{ sw_path }}/arteria/archive_upload_venv"
+archive_upload_env_root: "{{ anaconda_path }}/envs/archive-upload"
 archive_upload_src_path: "{{ sw_path }}/arteria/archive_upload_src"
 
 archive_upload_config_root: "{{ ngi_pipeline_conf }}/arteria/archive_upload/"
@@ -29,8 +29,6 @@ archive_upload_log_dir: "/proj/{{ ngi_pipeline_upps_delivery }}/private/log/arte
 archive_upload_port_prod: 10480
 archive_upload_port_stage: 10481 
 archive_upload_cores_to_use: 2
-
-archive_upload_virtual_env_command: "/usr/bin/python /lupus/ngi/irma3/virtualenv-15.0.0/virtualenv.py"
 
 # We want to fake a successful return code for the dsmc subprocess for some certain warnings.
 # Otherwise the Arteria workflow in Stackstorm would be marked as failed when it actually suceeded.  

--- a/roles/archive-upload-ws/meta/main.yml
+++ b/roles/archive-upload-ws/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - { role: anaconda, tags: anaconda }

--- a/roles/archive-upload-ws/tasks/1_install.yml
+++ b/roles/archive-upload-ws/tasks/1_install.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: create virtual python env for archive-upload
+  shell: "{{ conda_bin }} create --name archive-upload python=2.7"
+  args: 
+    creates: "{{ archive_upload_env_root }}"
+
 - name: get archive-upload from git
   git:
     repo: "{{ archive_upload_repo }}"
@@ -8,19 +13,17 @@
 
 - name: install archive-upload requirements
   pip:
-      requirements: "{{ archive_upload_src_path }}/requirements/prod"
-      chdir: "{{ archive_upload_src_path }}"
-      virtualenv: "{{ archive_upload_env_root }}"
-      virtualenv_command: "{{ archive_upload_virtual_env_command }}"
-      state: present
-      extra_args: "-U"
+    requirements: "{{ archive_upload_src_path }}/requirements/prod"
+    chdir: "{{ archive_upload_src_path }}"
+    virtualenv: "{{ archive_upload_env_root }}"
+    state: present
+    extra_args: "-U"
 
 - name: install archive-upload
   pip:
-      name: .
-      chdir: "{{ archive_upload_src_path }}"
-      virtualenv: "{{ archive_upload_env_root }}"
-      virtualenv_command: "{{ archive_upload_virtual_env_command }} "
-      state: present
-      extra_args: "-U"
+    name: .
+    chdir: "{{ archive_upload_src_path }}"
+    virtualenv: "{{ archive_upload_env_root }}"
+    state: present
+    extra_args: "-U"
 

--- a/roles/arteria-checksum-ws/defaults/main.yml
+++ b/roles/arteria-checksum-ws/defaults/main.yml
@@ -20,7 +20,7 @@ arteria_checksum_version: v1.0.4
 # to disappear when the wildwest directory is cleaned out with every 
 # staging sync. 
 arteria_checksum_monitored_path: "/proj/{{ ngi_pipeline_upps_delivery }}/incoming"
-arteria_checksum_env_root: "{{ sw_path }}/arteria/checksum_venv/"
+arteria_checksum_env_root: "{{ anaconda_path }}/envs/arteria-checksum"
 arteria_checksum_src_path: "{{ sw_path }}/arteria/checksum_src/"
 arteria_checksum_config_root: "{{ ngi_pipeline_conf }}/arteria/checksum/"
 arteria_checksum_md5sum_log_dir: "/proj/{{ ngi_pipeline_upps_delivery }}/private/log/arteria/checksum_md5sum/"
@@ -30,5 +30,3 @@ arteria_checksum_service_log: "/proj/{{ ngi_pipeline_upps_delivery }}/private/lo
 arteria_checksum_port_prod: 10420
 arteria_checksum_port_stage: 10421
 arteria_checksum_cores_to_use: 8
-
-arteria_checksum_virtual_env_command: "/usr/bin/python /lupus/ngi/irma3/virtualenv-15.0.0/virtualenv.py"

--- a/roles/arteria-checksum-ws/meta/main.yml
+++ b/roles/arteria-checksum-ws/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - { role: anaconda, tags: anaconda }

--- a/roles/arteria-checksum-ws/tasks/1_install.yml
+++ b/roles/arteria-checksum-ws/tasks/1_install.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: create virtual python env for arteria-checksum
+  shell: "{{ conda_bin }} create --name arteria-checksum python=2.7"
+  args: 
+    creates: "{{ arteria_checksum_env_root }}"
+
 - name: get arteria-checksum from git
   git:
     repo: "{{ arteria_checksum_repo }}"
@@ -8,19 +13,17 @@
 
 - name: install arteria-checksum requirements
   pip:
-      requirements: "{{ arteria_checksum_src_path }}/requirements/prod"
-      chdir: "{{ arteria_checksum_src_path }}"
-      virtualenv: "{{ arteria_checksum_env_root }}"
-      virtualenv_command: "{{ arteria_checksum_virtual_env_command }}"
-      state: present
-      extra_args: "-U"
+    requirements: "{{ arteria_checksum_src_path }}/requirements/prod"
+    chdir: "{{ arteria_checksum_src_path }}"
+    virtualenv: "{{ arteria_checksum_env_root }}"
+    state: present
+    extra_args: "-U"
 
 - name: install arteria-checksum
   pip:
-      name: .
-      chdir: "{{ arteria_checksum_src_path }}"
-      virtualenv: "{{ arteria_checksum_env_root }}"
-      virtualenv_command: "{{ arteria_checksum_virtual_env_command }}"
-      state: present
-      extra_args: "-U"
+    name: .
+    chdir: "{{ arteria_checksum_src_path }}"
+    virtualenv: "{{ arteria_checksum_env_root }}"
+    state: present
+    extra_args: "-U"
 

--- a/roles/arteria-staging/defaults/main.yml
+++ b/roles/arteria-staging/defaults/main.yml
@@ -1,1 +1,1 @@
-arteria_staging_path: "/lupus/ngi/staging/latest/sw/arteria/arteria_staging/"  
+arteria_staging_path: "{{ sw_path }}/arteria/arteria_staging/"  

--- a/roles/arteria-staging/templates/arteria-staging.screen.j2
+++ b/roles/arteria-staging/templates/arteria-staging.screen.j2
@@ -1,6 +1,6 @@
 sessionname arteria-staging
 zombie kr
 verbose on
-screen -t checksum 0 bash -i -c "{{ arteria_checksum_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/checksum-ws --configroot={{ arteria_checksum_config_root }} --port={{ arteria_checksum_port_stage }} --debug"
+screen -t checksum 0 bash -i -c "{{ arteria_checksum_env_root }}/bin/python {{ arteria_checksum_env_root }}/bin/checksum-ws --configroot={{ arteria_checksum_config_root }} --port={{ arteria_checksum_port_stage }} --debug"
 screen -t delivery 1 bash -i -c "{{ arteria_delivery_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port_stage }} --debug"
-screen -t upload 2 bash -i -c "{{ arteria_checksum_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/checksum-ws --configroot=/lupus/ngi/staging/latest/conf/arteria/archive_upload/ --port=10481 --debug"
+screen -t upload 2 bash -i -c "{{ archive_upload_env_root }}/bin/python {{ archive_upload_env_root }}/bin/archive-upload-ws --configroot={{ archive_upload_config_root }} --port={{ archive_upload_port_stage }} --debug"

--- a/roles/arteria-staging/templates/arteria-staging.screen.j2
+++ b/roles/arteria-staging/templates/arteria-staging.screen.j2
@@ -2,4 +2,5 @@ sessionname arteria-staging
 zombie kr
 verbose on
 screen -t checksum 0 bash -i -c "{{ arteria_checksum_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/checksum-ws --configroot={{ arteria_checksum_config_root }} --port={{ arteria_checksum_port_stage }} --debug"
-screen -t delivery 2 bash -i -c "{{ arteria_delivery_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port_stage }} --debug"
+screen -t delivery 1 bash -i -c "{{ arteria_delivery_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port_stage }} --debug"
+screen -t upload 2 bash -i -c "{{ arteria_checksum_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/checksum-ws --configroot=/lupus/ngi/staging/latest/conf/arteria/archive_upload/ --port=10481 --debug"

--- a/roles/arteria-staging/templates/arteria-staging.screen.j2
+++ b/roles/arteria-staging/templates/arteria-staging.screen.j2
@@ -1,5 +1,5 @@
 sessionname arteria-staging
 zombie kr
 verbose on
-screen -t checksum 0 bash -i -c "{{ arteria_checksum_env_root }}/bin/checksum-ws --configroot={{ arteria_checksum_config_root }} --port={{ arteria_checksum_port_stage }}  --debug"
+screen -t checksum 0 bash -i -c "{{ arteria_checksum_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/checksum-ws --configroot={{ arteria_checksum_config_root }} --port={{ arteria_checksum_port_stage }} --debug"
 screen -t delivery 2 bash -i -c "{{ arteria_delivery_env_root }}/bin/python {{ arteria_delivery_env_root }}/bin/delivery-ws --configroot={{ arteria_delivery_config_root }} --port={{ arteria_delivery_port_stage }} --debug"

--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -1,3 +1,3 @@
 nextflow_java: "/sw/comp/java/x86_64/sun_jdk1.8.0_151"
-nextflow_version_tag: "20.11.0-edge"
+nextflow_version_tag: "v20.11.0-edge"
 nextflow_download_url: "https://github.com/nextflow-io/nextflow/releases/download/{{ nextflow_version_tag }}/nextflow"

--- a/roles/nf-core-biocontainer-temp/tasks/main.yml
+++ b/roles/nf-core-biocontainer-temp/tasks/main.yml
@@ -38,6 +38,9 @@
   synchronize:
     src: "{{ ngi_containers }}/download/biocontainers/nf-core-rnaseq_v3.0/"
     dest: "{{ ngi_containers }}/biocontainers/"
+    archive: no
+    group: yes
+    recursive: true
 
 - name: Clean download
   file:


### PR DESCRIPTION
Fixes a problem where virtual envs for `arteria-checksum` and `archive-upload` would be created with python 3 rather than 2.

Also: Fixed "v" missing from nextflow version and updated synchronize parameters to avoid issues with permissions. 