### PR TITLE
Update ngi_pipeline version to increase default qc walltime

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -19,7 +19,7 @@ bash_env_sthlm_script: sourceme_sthlm.sh
 
 ngi_pipeline_repo: https://github.com/NationalGenomicsInfrastructure/ngi_pipeline.git
 ngi_pipeline_dest: "{{ sw_path }}/ngi_pipeline"
-ngi_pipeline_version: fa0eff3a97dc1f17264b084842a580f029f78bee
+ngi_pipeline_version: e4d2d19942c67b213f25dca5bb3331f30b4a6b1f
 NGI_venv_name: "NGI"
 NGI_venv_py3_name: "NGI_py3"
 ngi_pipeline_venv: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_name }}"


### PR DESCRIPTION
A tiny change to include in the monthly release.