### PR TITLE
Bump TACA, flowcell parser, taca-ngi-pipeline, ngi-pipeline and add new app Readmes for Sthlm

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -19,7 +19,7 @@ bash_env_sthlm_script: sourceme_sthlm.sh
 
 ngi_pipeline_repo: https://github.com/NationalGenomicsInfrastructure/ngi_pipeline.git
 ngi_pipeline_dest: "{{ sw_path }}/ngi_pipeline"
-ngi_pipeline_version: e4d2d19942c67b213f25dca5bb3331f30b4a6b1f
+ngi_pipeline_version: d1f206f2e28c6af498c711ff8b8d4a479d98440d
 NGI_venv_name: "NGI"
 NGI_venv_py3_name: "NGI_py3"
 ngi_pipeline_venv: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_name }}"

--- a/roles/multiqc/defaults/main.yml
+++ b/roles/multiqc/defaults/main.yml
@@ -1,6 +1,6 @@
 multiqc_repo: https://github.com/ewels/MultiQC.git
 multiqc_dest: "{{ sw_path }}/multiqc"
-multiqc_version: "v1.9"
+multiqc_version: "v1.10"
 
 multiqc_ngi_repo: https://github.com/NationalGenomicsInfrastructure/MultiQC_NGI.git
 multiqc_ngi_dest: "{{ sw_path }}/multiqc_ngi"

--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ngi_reports_repo: https://github.com/NationalGenomicsInfrastructure/ngi_reports.git
 ngi_reports_dest: "{{ sw_path }}/ngi_reports"
-ngi_reports_version: eb4185756a22223fc3c746ee9fb969f75055e576
+ngi_reports_version: c845cb41e8b1c2853b4e32a9ced3ebc87e58a825
 ngi_reports_log: "/log/ngi_reports.log"
 ngi_reports_log_sthlm: "{{ ngi_pipeline_sthlm_path }}/{{ ngi_reports_log }}"
 

--- a/roles/sarek/tasks/main.yml
+++ b/roles/sarek/tasks/main.yml
@@ -58,7 +58,6 @@
     src: "DELIVERY.README.SAREK.txt.j2"
     dest: "{{ ngi_resources }}/TACA/{{ item.site }}/DELIVERY.README.SAREK.txt"
   with_items:
-    - site: sthlm
     - site: upps
 
 - name: Set alias for pipeline

--- a/roles/taca/defaults/main.yml
+++ b/roles/taca/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 taca_ngi_repo: https://github.com/SciLifeLab/taca-ngi-pipeline.git
 taca_ngi_dest: "{{ sw_path }}/taca-ngi-pipeline"
-taca_ngi_version: edbe7504b1ac67dbbf06e6c46f10ce0e6ca9291f
+taca_ngi_version: 1d7ca548099ed3b08dd33fff59f6b8652b323707
 
 statusdb_repo: "https://github.com/SciLifeLab/statusdb.git"
 statusdb_dest: "{{ sw_path }}/statusdb"
@@ -9,8 +9,8 @@ statusdb_version: "f21b4124e512aa50babe665f9839fcbc7205bc26"
 
 flowcell_parser_repo: "https://github.com/SciLifeLab/flowcell_parser.git"
 flowcell_parser_dest: "{{ sw_path }}/flowcell_parser"
-flowcell_parser_version: "320bd8c8a5669fd4552f1f8f88232cde613c0cf2"
+flowcell_parser_version: "88a43033009dae455de8c89e00379b8e4a623259"
 
 taca_repo: "https://github.com/SciLifeLab/TACA.git"
 taca_dest: "{{ sw_path }}/TACA"
-taca_version: 07f86e8022a042b870cfc83caf90ce70df0a26e3
+taca_version: e8df5d5d78ce9e6d3946caeeb5f2fdc3ee18492b

--- a/roles/taca/templates/create_delivery_readme_softlinks.sh.j2
+++ b/roles/taca/templates/create_delivery_readme_softlinks.sh.j2
@@ -15,3 +15,5 @@ fi
 
 ln -s /lupus/ngi/{{ deployment_environment }}/latest/sw/taca-ngi-pipeline/delivery_readmes/DELIVERY.README.RAW_DATA.txt {{ proj_root }}/$1/nobackup/NGI/softlinks/DELIVERY.README.RAW_DATA.txt
 ln -s /lupus/ngi/{{ deployment_environment }}/latest/sw/taca-ngi-pipeline/delivery_readmes/DELIVERY.README.MethylSeq.txt {{ proj_root }}/$1/nobackup/NGI/softlinks/DELIVERY.README.MethylSeq.txt
+ln -s /lupus/ngi/{{ deployment_environment }}/latest/sw/taca-ngi-pipeline/delivery_readmes/DELIVERY.README.RNASeq.txt {{ proj_root }}/$1/nobackup/NGI/softlinks/DELIVERY.README.RNASeq.txt
+ln -s /lupus/ngi/{{ deployment_environment }}/latest/sw/taca-ngi-pipeline/delivery_readmes/DELIVERY.README.Sarek.txt {{ ngi_resources }}/TACA/sthlm/DELIVERY.README.SAREK.txt


### PR DESCRIPTION
**Updates**
* ngi-pipeline : pinned inflect for py2.7.
* taca-ngi-pipeline: Add new RNASeq and Sarek delivery readmes for Sthlm.
* Flowcell parser:  Fix data format for NextSeq2000.
* TACA: Various updates to support NextSeq2000.
* Multiqc: Updated to v1.10
* ngi_reports: Support for NextSeq2000 and updates to text from SWEDAC regarding deviations.