### PR TITLE
Bump methylseq,fc_parser,TACA, add nanoseq, cleanup multiqc role

### DIFF
--- a/roles/multiqc/tasks/main.yml
+++ b/roles/multiqc/tasks/main.yml
@@ -6,13 +6,6 @@
        force=yes
 
 #Remember to use --upgrade flag if using commit-id
-#Using the python3 env
-- name: Temporarily fix matplotlib at v3.2.2 to get rid of warnings
-  pip:
-    name: matplotlib
-    version: 3.2.2
-    executable: "{{ sw_path }}/anaconda/envs/{{ NGI_venv_py3_name }}/bin/pip"
-
 - name: Install MultiQC
   pip:
     name: "file:{{ multiqc_dest }}"

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -4,7 +4,7 @@ nextflow_download_url: "https://github.com/nextflow-io/nextflow/releases/downloa
 nf_core_env: "/lupus/ngi/irma3/nf-core-env"
 pipelines:
   - name: methylseq
-    release: 1.5
+    release: 1.6
   - name: ampliseq
     release: 1.1.2
   - name: atacseq
@@ -12,4 +12,6 @@ pipelines:
   - name: viralrecon
     release: 1.1.0
   - name: rnafusion
-    release: 1.2.0    
+    release: 1.2.0
+  - name: nanoseq
+    release: 1.1.0

--- a/roles/taca/defaults/main.yml
+++ b/roles/taca/defaults/main.yml
@@ -9,8 +9,8 @@ statusdb_version: "f21b4124e512aa50babe665f9839fcbc7205bc26"
 
 flowcell_parser_repo: "https://github.com/SciLifeLab/flowcell_parser.git"
 flowcell_parser_dest: "{{ sw_path }}/flowcell_parser"
-flowcell_parser_version: "88a43033009dae455de8c89e00379b8e4a623259"
+flowcell_parser_version: "4ec4331bf6f968bb4a83b00c9c111d87823049de"
 
 taca_repo: "https://github.com/SciLifeLab/TACA.git"
 taca_dest: "{{ sw_path }}/TACA"
-taca_version: e8df5d5d78ce9e6d3946caeeb5f2fdc3ee18492b
+taca_version: d21622638a054082375537f319c5f4a928f0a5c6


### PR DESCRIPTION
Updates

* nfcore/methylseq: Version bump to v1.6
* nfcore/nanoseq: New addition at v1.1.0
* TACA: Updates to NextSeq2000 flow and additional 10x index types and masks
* Flowcell parser: Updates to NextSeq 2000 flow
* multiqc: Remove the temporary matplotlib fix at v3.2.2 (fixed in multiqc v1.10).
