### PR TITLE
Update multiqc to 1.11 and bump TACA version

### DIFF
--- a/roles/multiqc/defaults/main.yml
+++ b/roles/multiqc/defaults/main.yml
@@ -1,6 +1,6 @@
 multiqc_repo: https://github.com/ewels/MultiQC.git
 multiqc_dest: "{{ sw_path }}/multiqc"
-multiqc_version: "v1.10.1"
+multiqc_version: "v1.11"
 
 multiqc_ngi_repo: https://github.com/NationalGenomicsInfrastructure/MultiQC_NGI.git
 multiqc_ngi_dest: "{{ sw_path }}/multiqc_ngi"

--- a/roles/taca/defaults/main.yml
+++ b/roles/taca/defaults/main.yml
@@ -13,4 +13,4 @@ flowcell_parser_version: "4ec4331bf6f968bb4a83b00c9c111d87823049de"
 
 taca_repo: "https://github.com/SciLifeLab/TACA.git"
 taca_dest: "{{ sw_path }}/TACA"
-taca_version: d21622638a054082375537f319c5f4a928f0a5c6
+taca_version: 41377c8fc4fed3baa400022a4735714a785a2698


### PR DESCRIPTION
Updates

- Multiqc to v1.11
- Update TACA version

@ssjunnebo Should we include the recent updates to taca-ngi-pipeline too?