### PR TITLE
Sarek wes defaults upps

### DIFF
--- a/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
+++ b/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
@@ -51,6 +51,7 @@ sarek:
     custom_config_base: {{ sarek_dest }}/configs/
     igenomes_ignore: " "
     no_gatk_spark: " "
+    generate_gvcf: " "
     sequencing_center: {{ ngi_pipeline_sequencing_center }}
 
 nextflow:

--- a/roles/sarek/tasks/main.yml
+++ b/roles/sarek/tasks/main.yml
@@ -53,10 +53,17 @@
     src: "apply_recalibration.sh.j2"
     dest: "{{ ngi_resources }}/TACA/apply_recalibration.sh"
 
-- name: Create Delivery READMEs and add to TACA resources
+- name: Create Delivery READMEs for WGS and add to TACA resources
   template:
     src: "DELIVERY.README.SAREK.txt.j2"
     dest: "{{ ngi_resources }}/TACA/{{ item.site }}/DELIVERY.README.SAREK.txt"
+  with_items:
+    - site: upps
+
+- name: Create Delivery READMEs for WES and add to TACA resources
+  template:
+    src: "DELIVERY.README.SAREK.WES.md.j2"
+    dest: "{{ ngi_resources }}/TACA/{{ item.site }}/DELIVERY.README.SAREK.WES.md"
   with_items:
     - site: upps
 

--- a/roles/sarek/templates/DELIVERY.README.SAREK.WES.md.j2
+++ b/roles/sarek/templates/DELIVERY.README.SAREK.WES.md.j2
@@ -1,0 +1,98 @@
+# DELIVERY OF RESULTS FROM EXOME ANALYSIS WITH SAREK
+
+## Analysis
+Samples were analysed with the Sarek pipeline release 2.6.1. In short, the pipeline does the following:
+Reads from fastq-files were mapped to a reference genome using BWA.
+Bam-files were de-duplicated with GATK MarkDuplicates.
+Base quality score recalibration tables were created with GATK BaseRecalibrator. 
+The tables were then used in GATK ApplyBQSR to create recalibrated bam-files.
+SNVs and small indels were called with GATK HaplotypeCaller.
+Variants were annoted with SnpEff.
+
+For details on the pipeline, folder structure and how to interpret results, please refer to the Sarek documentation:
+https://nf-co.re/sarek
+
+After running the pipeline, Picard CollectHsMetrics was used to evaluate the coverage
+
+## Delivery structure, directories and files:
+
+```
+
+├── Annotation
+│   ├── <sample1 name>
+│   │   └── snpEff
+│   └── <sample2 name>
+│       └── snpEff
+├── DELIVERY.README.SAREK.WES.txt
+├── multiqc_ngi
+│   ├── <project>_multiqc_report_data.zip
+│   └── <project>_multiqc_report.html
+├── pipeline_info
+│   ├── results_description.html
+│   └── software_versions.csv
+├── Preprocessing
+│   ├── TSV
+│   │   ├── duplicates_marked_no_table.tsv
+│   │   ├── duplicates_marked_no_table_<sample1 name>.tsv
+│   │   ├── duplicates_marked_no_table_<sample2 name>.tsv
+│   │   ├── duplicates_marked.tsv
+│   │   ├── duplicates_marked_<sample1 name>.tsv
+│   │   └── duplicates_marked_<sample2 name>.tsv
+│   ├── <sample1 name>
+│   │   └── DuplicatesMarked
+│   │       ├── <sample1 name>.md.bam
+│   │       ├── <sample1 name>.md.bam.bai
+│   │       └── <sample1 name>.recal.table
+│   └── <sample2 name>
+│       └── DuplicatesMarked
+│           ├── <sample2 name>.md.bam
+│           ├── <sample2 name>.md.bam.bai
+│           └── <sample2 name>.recal.table
+├── Reports
+│   ├── HsMetrics
+│   │   ├── <sample1 name>
+│   │   └── <sample2 name>
+│   ├── <sample1 name>
+│   │   ├── bamQC
+│   │   ├── BCFToolsStats
+│   │   ├── FastQC
+│   │   ├── MarkDuplicates
+│   │   ├── SamToolsStats
+│   │   ├── snpEff
+│   │   └── VCFTools
+│   └── <sample2 name>
+│       ├── bamQC
+│       ├── BCFToolsStats
+│       ├── FastQC
+│       ├── MarkDuplicates
+│       ├── SamToolsStats
+│       ├── snpEff
+│       └── VCFTools
+├── Resources
+│   └── apply_recalibration.sh
+├── <sample1 name>.lst
+├── <sample1 name>.md5
+├── <sample2 name>.lst
+├── <sample2 name>.md5
+└── VariantCalling
+    ├── <sample1 name>
+    │   ├── HaplotypeCaller
+    │   └── HaplotypeCallerGVCF
+    └── <sample2 name>
+        ├── HaplotypeCaller
+        └── HaplotypeCallerGVCF
+
+```
+
+## Known issues
+
+- Twist bait intervals are not publicly available and therefore, when running CollectHsMetrics (Picard), the target intervals are used to specify both target and bait. 
+This will lead to some incorrect entries in the HsMetrics table in the MultiQC-report, i.e. entries regarding baits should be neglected.
+
+## Additional information 
+
+- The original target file used for the analysis can be found here https://www.twistbioscience.com/resources/bed-file/twist-human-comprehensive-exome-panel-bed-files
+Note that each region in this file was padded with 100 bp upstream and downstream before submitting it to the pipeline. 
+- Note that samples that are sequenced on more than one flowcell/lane will be suffixed accordingly for some modules in the MultiQC report.
+A sample that has been sequenced twice will for some metrics be presented as a joint vaule for <sample name>, and with one value per run, i.e. <sample name>_1 and <sample_name>_2. 
+- To apply the recalibrations table to the deduplicated .bam-files use the script Resources/apply_recalibration.sh  

--- a/roles/taca/tasks/main.yml
+++ b/roles/taca/tasks/main.yml
@@ -45,6 +45,9 @@
 - name: Deploy uppsala sarek config
   template: src="site_taca_sarek_delivery.yml.j2" dest="{{ ngi_pipeline_conf }}/TACA/{{ site }}_taca_sarek_delivery.yml"
 
+- name: Deploy uppsala sarek WES config
+  template: src="site_taca_sarek_wes_delivery.yml.j2" dest="{{ ngi_pipeline_conf }}/TACA/{{ site }}_taca_sarek_wes_delivery.yml"
+
 - set_fact:
     site: "sthlm"
     site_full: "stockholm"
@@ -68,6 +71,9 @@
 
 - name: Deploy sthlm sarek config
   template: src="site_taca_sarek_delivery.yml.j2" dest="{{ ngi_pipeline_conf }}/TACA/{{ site }}_taca_sarek_delivery.yml"
+
+- name: Deploy sthlm sarek WES config
+  template: src="site_taca_sarek_wes_delivery.yml.j2" dest="{{ ngi_pipeline_conf }}/TACA/{{ site }}_taca_sarek_wes_delivery.yml"
 
 - name: Deploy application specific stockholm configs
   template: src="site_app_specific_delivery.yml.j2" dest="{{ ngi_pipeline_conf }}/TACA/{{ site }}_taca_{{ item }}_delivery.yml"

--- a/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
@@ -66,8 +66,8 @@ deliver:
               required: True
               no_digest_cache: True
         -
-            - {{ ngi_resources }}/TACA/{{ site }}/DELIVERY.README.SAREK.WES.j2
+            - {{ ngi_resources }}/TACA/{{ site }}/DELIVERY.README.SAREK.WES.md
             - <STAGINGPATH>/
             -
               required: True
-              no_digest_cache: true
+              no_digest_cache: True

--- a/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
@@ -1,0 +1,73 @@
+log:
+    file: "{{ ngi_pipeline_site_path }}/log/taca.log"
+
+deliver:
+    rootpath: "{{ proj_root }}/{{ ngi_pipeline_site_delivery }}/nobackup/NGI"
+    analysispath: <ROOTPATH>/ANALYSIS/<PROJECTID>
+    stagingpath: <ROOTPATH>/DELIVERY/<PROJECTID>
+    operator: "{{ recipient_mail }}"
+    hash_algorithm: md5
+
+    files_to_deliver:
+        -
+          - <ANALYSISPATH>/results/multiqc_ngi/*multiqc_report.html
+          - <STAGINGPATH>/multiqc_ngi/
+          -
+            required: True
+        -
+          - <ANALYSISPATH>/results/multiqc_ngi/*multiqc_report_data.zip
+          - <STAGINGPATH>/multiqc_ngi/
+          -
+            required: True
+        -
+          - <ANALYSISPATH>/results/Annotation/<SAMPLEID>/
+          - <STAGINGPATH>/Annotation/<SAMPLEID>/
+          -
+            required: True
+        -
+          - <ANALYSISPATH>/results/pipeline_info/results_description.html
+          - <STAGINGPATH>/pipeline_info/
+          -
+            required: True
+        -
+          - <ANALYSISPATH>/results/pipeline_info/software_versions.csv
+          - <STAGINGPATH>/pipeline_info/
+          -
+            required: True
+         -
+          - <ANALYSISPATH>/results/Preprocessing/TSV/duplicates_marked_<SAMPLEID>.tsv
+          - <STAGINGPATH>/Preprocessing/TSV
+          -
+            required: True
+        -
+            - <ANALYSISPATH>/results/Preprocessing/<SAMPLEID>/DuplicatesMarked/*
+            - <STAGINGPATH>/Preprocessing/<SAMPLEID>/DuplicatesMarked/
+            -
+              required: True
+        -
+            - <ANALYSISPATH>/results/Reports/<SAMPLEID>/
+            - <STAGINGPATH>/Reports/<SAMPLEID>/
+            -
+              required: True
+        -
+            - <ANALYSISPATH>/results/Reports/HsMetrics/<SAMPLEID>*
+            - <STAGINGPATH>/Reports/HsMetrics/<SAMPLEID>/
+            -
+              required: True
+        -
+            - <ANALYSISPATH>/results/VariantCalling/<SAMPLEID>/
+            - <STAGINGPATH>/VariantCalling/<SAMPLEID>/
+            -
+              required: True
+        -
+            - {{ ngi_resources }}/TACA/apply_recalibration.sh
+            - <STAGINGPATH>/Resources/
+            -
+              required: True
+              no_digest_cache: True
+        -
+            - {{ ngi_resources }}/TACA/{{ site }}/DELIVERY.README.SAREK.WES.j2
+            - <STAGINGPATH>/
+            -
+              required: True
+              no_digest_cache: true


### PR DESCRIPTION
In this PR the following changes are included:
- When running Sarek the parameter --generate_gvcf will be added as default.
- A new README.md for WES analysed with Sarek is now available.
- A new TACA-config for staging of WES analysed with Sarek is now available.