### PR TITLE
removed extra space in site_taca_sarek_wes_delivery.yml.j2

### DIFF
--- a/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
@@ -34,7 +34,7 @@ deliver:
           - <STAGINGPATH>/pipeline_info/
           -
             required: True
-         -
+        -
           - <ANALYSISPATH>/results/Preprocessing/TSV/duplicates_marked_<SAMPLEID>.tsv
           - <STAGINGPATH>/Preprocessing/TSV
           -


### PR DESCRIPTION
Extra space in line 37 gave following error: 
```
File "/lupus/ngi/production/v1.27/sw/anaconda/envs/NGI/lib/python2.7/site-packages/yaml/parser.py", line 393, in parse_block_sequence_entry
    "expected <block end>, but found %r" % token.id, token.start_mark)
yaml.parser.ParserError: while parsing a block collection
  in "/lupus/ngi/production/latest/conf/TACA/upps_taca_sarek_wes_delivery.yml", line 12, column 9
expected <block end>, but found '<block sequence start>'
```