### PR TITLE
Set up required plugins dir for nextflow

### DIFF
--- a/roles/nextflow/tasks/main.yml
+++ b/roles/nextflow/tasks/main.yml
@@ -10,6 +10,9 @@
 - name: Create NextFlow installation subdirectory
   file: path="{{ nextflow_dest }}/workfiles" state=directory mode=g+rwXs
 
+- name: Create NextFlow installation plugins subdirectory
+  file: path="{{ nextflow_dest }}/workfiles/plugins" state=directory mode=g+rwXs
+
 - name: Download NextFlow
   get_url: url="{{ nextflow_download_url }}" dest="{{ nextflow_dest }}/nextflow" mode="u+rwx,g=rwx"
 


### PR DESCRIPTION
Nextflow tries to create a plugins directory if it doesn't exist, but only users in the ngi-sw group have write access.